### PR TITLE
fix layer not found errors in function images build

### DIFF
--- a/.github/workflows/build_function_images.yml
+++ b/.github/workflows/build_function_images.yml
@@ -19,5 +19,11 @@ jobs:
       with:
         ref: master
     - name: docker build images
+    # Consecutive COPY commands in Dockerfile fail on github runners
+    # Added "DOCKER_BUILDKIT=1" as a temporary fix
+    # more discussion on the same issue:
+      # https://github.com/moby/moby/issues/37965
+      # https://github.community/t/attempting-to-build-docker-image-with-copy-from-on-actions/16715
+      # https://stackoverflow.com/questions/51115856/docker-failed-to-export-image-failed-to-create-image-failed-to-get-layer
       run: |
-        docker build ./function-images/${{ matrix.image }}
+        DOCKER_BUILDKIT=1 docker build ./function-images/${{ matrix.image }}

--- a/function-images/lr_serving/Dockerfile
+++ b/function-images/lr_serving/Dockerfile
@@ -13,6 +13,7 @@ RUN apk add --no-cache \
     pip install --disable-pip-version-check --no-build-isolation pandas==1.0.5 && \
     pip install --disable-pip-version-check --no-build-isolation protobuf==3.11.3 && \
     pip install --disable-pip-version-check --no-build-isolation grpcio==1.26.0 && \
+    pip install --disable-pip-version-check --no-build-isolation pybind11 && \
     \
     # scipy 1.4.x releases are broken on Alpine due to: https://github.com/scipy/scipy/issues/11319
     #pip install --disable-pip-version-check --no-build-isolation scipy && \


### PR DESCRIPTION
Consecutive COPY commands in Dockerfile fail on github runners.
Added "DOCKER_BUILDKIT=1" Environment variable as a temporary fix.
Refer to the links below for more discussion on the issue:
    https://github.com/moby/moby/issues/37965
    https://github.community/t/attempting-to-build-docker-image-with-copy-from-on-actions/16715
    https://stackoverflow.com/questions/51115856/docker-failed-to-export-image-failed-to-create-image-failed-to-get-layer

Signed-off-by: Shyam Jesalpura <s.jesalpura@gmail.com>