### PR TITLE
Increase startVM timeout value

### DIFF
--- a/functions.go
+++ b/functions.go
@@ -350,7 +350,7 @@ func (f *Function) AddInstance() *metrics.Metric {
 
 	var metr *metrics.Metric = nil
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*120)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute*5)
 	defer cancel()
 
 	if f.isSnapshotReady {


### PR DESCRIPTION
Increase startVM timeout value from 2 minutes to 5 minutes so that TestAllFunction passes on platforms with slow disks.
Signed-off-by: Dmitrii Ustiugov dmitrii.ustiugov@epfl.ch