### PR TITLE
MinIO server deployment in vHive (Kubernetes)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 
 ### Added
-
+- Support for MinIO S3 storage (non-replicated, non-distributed).
 
 ### Changed
 

--- a/configs/.wordlist.txt
+++ b/configs/.wordlist.txt
@@ -1,5 +1,3 @@
-linter
-md
 ACM
 Adileh
 al
@@ -47,6 +45,7 @@ CNI
 coderay
 colocated
 config
+configs
 CONFL
 congrats
 Congrats
@@ -82,6 +81,7 @@ Drumond
 DVFS
 Edouard
 env
+envsubst
 EPFL
 et
 EuroSys
@@ -108,6 +108,7 @@ grot
 Grot
 HDDs
 Hestness
+hostname
 HPCA
 href
 htaccess
@@ -161,6 +162,7 @@ ldquo
 Letraset
 Lim
 Linearizable
+linter
 LLC
 Lorem
 Lotfi
@@ -171,6 +173,7 @@ Manycore
 margaritov
 Margaritov
 Marios
+md
 MECS
 metadata
 Micheli
@@ -180,6 +183,7 @@ microVMs
 minio
 MinIO
 Mirzadeh
+mkdir
 mr
 MSI
 multi
@@ -237,6 +241,9 @@ priyank
 Priyank
 ps
 PTEMagnet
+pv
+PV
+pvc
 QoS
 QOS
 quickstart
@@ -286,6 +293,7 @@ SSD
 stateful
 Stavros
 sudo
+svc
 TCO
 th
 TLB
@@ -322,6 +330,7 @@ WOOT
 xl
 xml
 xyz
+yaml
 yml
 YY
 Zhu

--- a/configs/storage/minio/deployment.yaml
+++ b/configs/storage/minio/deployment.yaml
@@ -1,0 +1,44 @@
+apiVersion: apps/v1 #  for k8s versions before 1.9.0 use apps/v1beta2  and before 1.8.0 use extensions/v1beta1
+kind: Deployment
+metadata:
+  # This name uniquely identifies the Deployment
+  name: minio-deployment
+spec:
+  selector:
+    matchLabels:
+      app: minio
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        # Label is used as selector in the service.
+        app: minio
+    spec:
+      # Refer to the PVC created earlier
+      volumes:
+      - name: storage
+        persistentVolumeClaim:
+          # Name of the PVC created earlier
+          claimName: minio-pv-claim
+      containers:
+      - name: minio
+        # Pulls the default Minio image from Docker Hub
+        image: minio/minio:latest
+        args:
+        - server
+        - /storage
+        env:
+        # Minio access key and secret key
+        - name: MINIO_ACCESS_KEY
+          value: "minio"
+        - name: MINIO_SECRET_KEY
+          value: "minio123"
+        ports:
+        - containerPort: 9000
+          hostPort: 9000
+        # Mount the volume into the pod
+        volumeMounts:
+        - name: storage # must match the volume name, above
+          mountPath: "/storage"
+

--- a/configs/storage/minio/pv-claim.yaml
+++ b/configs/storage/minio/pv-claim.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  # This name uniquely identifies the PVC. Will be used in deployment below.
+  name: minio-pv-claim
+  labels:
+    app: minio-storage-claim
+spec:
+  # Read more about access modes here: http://kubernetes.io/docs/user-guide/persistent-volumes/#access-modes
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: local-storage
+  resources:
+    # This is the request for storage. Should be available in the cluster.
+    requests:
+      storage: 100Gi

--- a/configs/storage/minio/pv.yaml
+++ b/configs/storage/minio/pv.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: minio-pv
+spec:
+  capacity:
+    storage: 100Gi
+  volumeMode: Filesystem
+  accessModes:
+  - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Delete
+  storageClassName: local-storage
+  local:
+    path: ${MINIO_PATH}
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          - ${MINIO_NODE_NAME}

--- a/configs/storage/minio/service.yaml
+++ b/configs/storage/minio/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: minio-service
+spec:
+  clusterIP: 10.96.0.46
+  ports:
+    - port: 9000
+      targetPort: 9000
+      protocol: TCP
+  selector:
+    app: minio

--- a/docs/developers_guide.md
+++ b/docs/developers_guide.md
@@ -33,6 +33,7 @@ Once the container is up and running, follow [this](./quickstart_guide.md#setup-
 Record-and-Prefetch (REAP) snapshots.
 
 * vHive integrates with Kubernetes and Knative via its built-in CRI support.
+Currently, only Knative Serving is supported.
 
 * vHive supports arbitrary distributed setup of a serverless cluster.
 
@@ -41,7 +42,10 @@ Record-and-Prefetch (REAP) snapshots.
 * vHive has robust Continuous-Integration and our team is committed to deliver
 high-quality code.
 
-### Deploying a MinIO S3 service in a cluster
+
+### MinIO S3 service
+
+#### Deploying a MinIO service
 
 ```bash
 # create a folder in the local storage (on <MINIO_NODE_NAME> that is one of the Kubernetes nodes)
@@ -58,6 +62,18 @@ kubectl apply -f pv-claim.yaml
 kubectl apply -f deployment.yaml
 kubectl apply -f service.yaml
 ```
+
+#### Deleting the MinIO service that was created with the instructions above
+
+```bash
+kubectl delete deployment minio-deployment
+kubectl delete pvc minio-pv-claim
+kubectl delete svc minio-service
+kubectl delete pv minio-pv
+```
+
+Note that files in the bucket persist in the local filesystem after a persistent volume removal.
+
 
 ## Performance analysis
 

--- a/docs/developers_guide.md
+++ b/docs/developers_guide.md
@@ -41,6 +41,23 @@ Record-and-Prefetch (REAP) snapshots.
 * vHive has robust Continuous-Integration and our team is committed to deliver
 high-quality code.
 
+### Deploying a MinIO S3 service in a cluster
+
+```bash
+# create a folder in the local storage (on <MINIO_NODE_NAME> that is one of the Kubernetes nodes)
+sudo mkdir -p <MINIO_PATH>
+
+cd ./configs/storage/minio
+
+# create a persistent volume (PV) and the corresponding PV claim
+# specify the node name that would host the MinIO objects
+# (use `hostname` command for the local node)
+MINIO_NODE_NAME=<MINIO_NODE_NAME> MINIO_PATH=<MINIO_PATH> envsubst < pv.yaml | kubectl apply -f -
+kubectl apply -f pv-claim.yaml
+# create a storage app and the corresponding service
+kubectl apply -f deployment.yaml
+kubectl apply -f service.yaml
+```
 
 ## Performance analysis
 


### PR DESCRIPTION
This PR introduces MinIO object storage deployment in a Kubernetes cluster.

Current setup:
* The storage class is `local-storage` that requires node affinity, hence a node name and an existing path on it.
* The MinIO service is exposed by a custom IP (i.e., ClusterIP publishing type) that is specified in `service.yaml`

## Prerequisites

### Modify the YAML config of the MinIO service
The only type of storage that is supported is local storage (at least for now).

### Set up the MinIO service (after the cluster is up and running):
```bash
# create a folder in the local storage (on <MINIO_NODE_NAME> that is one of the Kubernetes nodes)
sudo mkdir -p <MINIO_PATH>

cd ./configs/storage/minio

# create a persistent volume (PV) and the corresponding PV claim
# specify the node name that would host the MinIO objects
# (use `hostname` command for the local node)
MINIO_NODE_NAME=<MINIO_NODE_NAME> MINIO_PATH=<MINIO_PATH> envsubst < pv.yaml | kubectl apply -f -
kubectl apply -f pv-claim.yaml
# create a storage app and the corresponding service
kubectl apply -f deployment.yaml
kubectl apply -f service.yaml
```


### How to check if MinIO is ready

#### Check if a `minio-*` pod is in the Running state with `kubectl get pods`

#### Using the MinIO client
An example of how the service can be accessed, using the [MinIO client](https://docs.min.io/docs/minio-client-quickstart-guide.html) ("minio" is the access key, "minio123" is the secret key):
```
mc alias set myminio http://10.96.0.46:9000 minio minio123
mc mb myminio/mybucket
mc cp README.md myminio/mybucket/tmp
```

### Cleanup procedure

Note that files in the bucket are persistent in the local filesystem despite persistent volume removal. 
```
kubectl delete deployment minio-deployment
kubectl delete pvc minio-pv-claim
kubectl delete svc minio-service
kubectl delete pv minio-pv
```

Signed-off-by: Dmitrii Ustiugov <dmitrii.ustiugov@ed.ac.uk>