### PR TITLE
vHive release v1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,29 @@
 
 ### Added
 
-- Extended the developers guide on the modes of operation, performance analysis and vhive development environment inside containers.
-- Created CI pipeline to run CRI tests inside containers using [kind](https://kind.sigs.k8s.io/).
 
 ### Changed
 
-- Using replace pragmas instead of Go modules.
-- Bump Go version to 1.15.
+### Fixed
+
+
+## v1.1
+
+### Added
+
+- Created a CI pipeline that runs CRI integration tests inside containers using [kind](https://kind.sigs.k8s.io/).
+- Added a developer image that runs a vHive k8s cluster in Docker, simplifying vHive development and debugging.
+- Extended the developers guide on the modes of operation, performance analysis and vhive development environment inside containers.
+- Added a slide deck of Dmitrii's talk at Amazon.
+- Added a commit linter and a spell checker for `*.md` files.
+
+### Changed
+
+- Use replace pragmas instead of Go modules.
+- Bump Go version to 1.15 in CI.
+- Deprecated Travis CI.
+
+### Fixed
+
+- Fixed the vHive cluster setup issue for clusters with >2 nodes [issue](https://github.com/ease-lab/vhive/issues/94). 
+

--- a/configs/.wordlist.txt
+++ b/configs/.wordlist.txt
@@ -1,4 +1,5 @@
-
+linter
+md
 ACM
 Adileh
 al


### PR DESCRIPTION
## Added

- Created a CI pipeline that runs CRI integration tests inside containers using kind.
- Added a developer image that runs a vHive k8s cluster in Docker, simplifying vHive development and debugging.
- Extended the developers guide on the modes of operation, performance analysis and vhive development environment inside containers.
- Added a slide deck of Dmitrii's talk at Amazon.
- Added a commit linter and a spell checker for `*.md` files.

## Changed
- Use replace pragmas instead of Go modules.
- Bump Go version to 1.15 in CI.
- Deprecated Travis CI.

## Fixed
- Fixed the vHive cluster setup issue for clusters with >2 nodes issue.

Signed-off-by: Dmitrii Ustiugov <dmitrii.ustiugov@ed.ac.uk>