### PR TITLE
modify scripts to support stock knative cluster startup

### DIFF
--- a/.github/workflows/cri_tests.yml
+++ b/.github/workflows/cri_tests.yml
@@ -57,3 +57,31 @@ jobs:
     - name: Cleaning
       if: ${{ always() }}
       run: ./scripts/github_runner/clean_cri_runner.sh
+
+  stock-containerd-test:
+    name: Stock Containerd test
+    runs-on: [self-hosted, cri]
+
+    steps:
+    - name: Setup TMPDIR
+      run: mkdir -p $HOME/tmp
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v2
+
+    - name: Start Containerd
+      run: sudo containerd &
+
+    - name: Create k8s cluster
+      run: ./scripts/cluster/create_one_node_cluster.sh stock-only && sleep 2m
+    
+    - name: Create helloworld container
+      run: KUBECONFIG=/etc/kubernetes/admin.conf kn service create helloworld-go --image gcr.io/knative-samples/helloworld-go --env TARGET="vHive CRI test"
+
+    - name: Cleaning
+      if: ${{ always() }}
+      run: ./scripts/github_runner/clean_cri_runner.sh stock-only
+
+
+
+

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -34,6 +34,9 @@ jobs:
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
 
+    - name: Setup System
+      run: ./scripts/setup_system.sh
+
     - name: Build
       run: go build -race -v -a ./...
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 - Support for MinIO S3 storage (non-replicated, non-distributed).
+- MicroVMs can now access the internet by default using custom host interface. (default route interface is used if no argument is provided)
+- Knative serving now can be tested separately from vHive. More info [here](https://github.com/ease-lab/vhive/wiki/Debugging-Knative-functions).
 
 ### Changed
 

--- a/docs/developers_guide.md
+++ b/docs/developers_guide.md
@@ -26,6 +26,24 @@ kind delete cluster --name <name>
 
 Once the container is up and running, follow [this](./quickstart_guide.md#setup-a-single-node-cluster-master-and-worker-functionality-on-the-same-node) guide to setup a single node vHive cluster.
 
+## Testing stock Knative images
+
+If you need to test your Knative images on stock Knative environment, use the commands below to setup an environment for that.
+```bash
+git clone https://github.com/ease-lab/vhive
+cd vhive
+./scripts/cloudlab/setup_node.sh stock-only
+sudo containerd
+./scripts/cluster/create_one_node_cluster.sh stock-only
+# wait for the containers to boot up using 
+watch kubectl get pods -A
+# once all the containers are ready/complete, you may start Knative functions
+kn service apply
+```
+### Clean up
+```bash
+./scripts/github_runner/clean_cri_runner.sh stock-only
+```
 
 ## High-level features
 

--- a/docs/quickstart_guide.md
+++ b/docs/quickstart_guide.md
@@ -125,6 +125,10 @@ sudo PATH=$PATH /usr/local/bin/firecracker-containerd --config /etc/firecracker-
 source /etc/profile && go build && sudo ./vhive
 ./scripts/cluster/create_one_node_cluster.sh
 ```
+### Clean up
+```bash
+./scripts/github_runner/clean_cri_runner.sh
+```
 
 ## CloudLab deployment notes
 

--- a/scripts/cloudlab/setup_node.sh
+++ b/scripts/cloudlab/setup_node.sh
@@ -26,16 +26,18 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 ROOT="$( cd $DIR && cd .. && cd .. && pwd)"
 SCRIPTS=$ROOT/scripts
 
+STOCK_CONTAINERD=$1
+
 source $SCRIPTS/install_go.sh
 $SCRIPTS/setup_system.sh
 
-if [ $1 != "no-vhive" ]; then
+if [ "$STOCK_CONTAINERD" != "stock-only" ]; then
     $SCRIPTS/setup_firecracker_containerd.sh
 fi
 
 $SCRIPTS/install_stock.sh
 
-if [ $1 != "no-vhive" ]; then
+if [ "$STOCK_CONTAINERD" != "stock-only" ]; then
     $SCRIPTS/create_devmapper.sh
 fi
 

--- a/scripts/cloudlab/setup_node.sh
+++ b/scripts/cloudlab/setup_node.sh
@@ -28,8 +28,14 @@ SCRIPTS=$ROOT/scripts
 
 source $SCRIPTS/install_go.sh
 $SCRIPTS/setup_system.sh
-$SCRIPTS/setup_firecracker_containerd.sh
+
+if [ $1 != "no-vhive" ]; then
+    $SCRIPTS/setup_firecracker_containerd.sh
+fi
 
 $SCRIPTS/install_stock.sh
-$SCRIPTS/create_devmapper.sh
+
+if [ $1 != "no-vhive" ]; then
+    $SCRIPTS/create_devmapper.sh
+fi
 

--- a/scripts/cluster/create_one_node_cluster.sh
+++ b/scripts/cluster/create_one_node_cluster.sh
@@ -26,9 +26,15 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 ROOT="$( cd $DIR && cd .. && cd .. && pwd)"
 
 # Create kubelet service
-$DIR/setup_worker_kubelet.sh
+$DIR/setup_worker_kubelet.sh $1
 
-sudo kubeadm init --ignore-preflight-errors=all --cri-socket /etc/firecracker-containerd/fccd-cri.sock --pod-network-cidr=192.168.0.0/16
+if [ $1 == "no-vhive" ]; then
+    CRI_SOCK="/run/containerd/containerd.sock"
+else
+    CRI_SOCK="/etc/firecracker-containerd/fccd-cri.sock"
+fi
+
+sudo kubeadm init --ignore-preflight-errors=all --cri-socket $CRI_SOCK --pod-network-cidr=192.168.0.0/16
 
 mkdir -p $HOME/.kube
 sudo cp -i /etc/kubernetes/admin.conf $HOME/.kube/config

--- a/scripts/cluster/create_one_node_cluster.sh
+++ b/scripts/cluster/create_one_node_cluster.sh
@@ -25,10 +25,12 @@ set -x
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 ROOT="$( cd $DIR && cd .. && cd .. && pwd)"
 
-# Create kubelet service
-$DIR/setup_worker_kubelet.sh $1
+STOCK_CONTAINERD=$1
 
-if [ $1 == "no-vhive" ]; then
+# Create kubelet service
+$DIR/setup_worker_kubelet.sh $STOCK_ONLY
+
+if [ "$STOCK_CONTAINERD" == "stock-only" ]; then
     CRI_SOCK="/run/containerd/containerd.sock"
 else
     CRI_SOCK="/etc/firecracker-containerd/fccd-cri.sock"
@@ -49,4 +51,4 @@ fi
 # Untaint master (allow pods to be scheduled on master) 
 kubectl taint nodes --all node-role.kubernetes.io/master-
 
-$DIR/setup_master_node.sh
+$DIR/setup_master_node.sh $STOCK_CONTAINERD

--- a/scripts/cluster/setup_master_node.sh
+++ b/scripts/cluster/setup_master_node.sh
@@ -25,6 +25,8 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 ROOT="$( cd $DIR && cd .. && cd .. && pwd)"
 
+STOCK_CONTAINERD=$1
+
 # Install Calico network add-on
 kubectl apply -f $ROOT/configs/calico/canal.yaml
 
@@ -42,10 +44,14 @@ kubectl apply -f $ROOT/configs/metallb/metallb-configmap.yaml
 curl -L https://istio.io/downloadIstio | ISTIO_VERSION=1.7.1 TARGET_ARCH=x86_64 sh -
 ./istio-1.7.1/bin/istioctl install -f $ROOT/configs/istio/istio-minimal-operator.yaml
 
-
 # Install KNative in the cluster
-kubectl apply --filename $ROOT/configs/knative_yamls/serving-crds.yaml
-kubectl apply --filename $ROOT/configs/knative_yamls/serving-core.yaml
+if [ "$STOCK_CONTAINERD" == "stock-only" ]; then
+    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.21.0/serving-crds.yaml
+    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.21.0/serving-core.yaml
+else
+    kubectl apply --filename $ROOT/configs/knative_yamls/serving-crds.yaml
+    kubectl apply --filename $ROOT/configs/knative_yamls/serving-core.yaml
+fi
 
 # magic DNS
 kubectl apply --filename $ROOT/configs/knative_yamls/serving-default-domain.yaml

--- a/scripts/cluster/setup_worker_kubelet.sh
+++ b/scripts/cluster/setup_worker_kubelet.sh
@@ -22,7 +22,9 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-if [ $1 == "no-vhive" ]; then
+STOCK_CONTAINERD=$1
+
+if [ "$STOCK_CONTAINERD" == "stock-only" ]; then
     CRI_SOCK="/run/containerd/containerd.sock"
 else
     CRI_SOCK="/etc/firecracker-containerd/fccd-cri.sock"

--- a/scripts/cluster/setup_worker_kubelet.sh
+++ b/scripts/cluster/setup_worker_kubelet.sh
@@ -22,9 +22,14 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+if [ $1 == "no-vhive" ]; then
+    CRI_SOCK="/run/containerd/containerd.sock"
+else
+    CRI_SOCK="/etc/firecracker-containerd/fccd-cri.sock"
+fi
 # Create kubelet service
 sudo sh -c 'cat <<EOF > /etc/systemd/system/kubelet.service.d/0-containerd.conf
 [Service]                                                 
-Environment="KUBELET_EXTRA_ARGS=--container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///etc/firecracker-containerd/fccd-cri.sock"
+Environment="KUBELET_EXTRA_ARGS=--container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix://'${CRI_SOCK}'"
 EOF'
 sudo systemctl daemon-reload

--- a/scripts/github_runner/clean_cri_runner.sh
+++ b/scripts/github_runner/clean_cri_runner.sh
@@ -24,8 +24,14 @@
 
 PWD="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
+STOCK_CONTAINERD=$1
+
 KUBECONFIG=/etc/kubernetes/admin.conf kn service delete --all
-sudo kubeadm reset --cri-socket /etc/firecracker-containerd/fccd-cri.sock -f
+if [ "$STOCK_CONTAINERD" == "stock-only" ]; then
+    sudo kubeadm reset --cri-socket /run/containerd/containerd.sock -f
+else
+    sudo kubeadm reset --cri-socket /etc/firecracker-containerd/fccd-cri.sock -f
+fi
 sudo pkill -INT vhive
 sudo pkill -9 firecracker-containerd
 sudo pkill -9 firecracker

--- a/scripts/github_runner/setup_runner_host.sh
+++ b/scripts/github_runner/setup_runner_host.sh
@@ -50,7 +50,7 @@ $PWD/../install_go.sh
 rm -rf /tmp/kind/
 git clone -b custom_docker_params_for_vHive https://github.com/ease-lab/kind /tmp/kind/
 cd /tmp/kind
-go build
+source /etc/profile && go build
 sudo mv kind /usr/local/bin/
 
 sudo usermod -aG docker $USER

--- a/scripts/github_runner/start_runners.sh
+++ b/scripts/github_runner/start_runners.sh
@@ -65,7 +65,7 @@ do
             vhiveease/integ_test_runner)
         ;;
     "cri")
-        ~/kind/kind create cluster --image vhiveease/cri_test_runner --name "cri-test-github-runner-${number}"
+        kind create cluster --image vhiveease/cri_test_runner --name "cri-test-github-runner-${number}"
         sleep 2m
         docker exec -it \
             -e RUNNER_ALLOW_RUNASROOT=1 \


### PR DESCRIPTION
- Add scripts to spawn a k8s cluster with stock containerd and knative for testing.
- Add stock containerd CRI test
- fixed kind path in start_runners.sh
- fixed kind build in setup_runner_host.sh



Signed-off-by: Shyam Jesal <s.jesalpura@gmail.com>