### PR TITLE
add zipkin request tracing for Knative functions

### DIFF
--- a/.github/workflows/cri_tests.yml
+++ b/.github/workflows/cri_tests.yml
@@ -73,7 +73,10 @@ jobs:
       run: sudo containerd &
 
     - name: Create k8s cluster
-      run: ./scripts/cluster/create_one_node_cluster.sh stock-only && sleep 2m
+      run: ./scripts/cluster/create_one_node_cluster.sh stock-only 
+      
+    - name: Deploy zipkin
+      run: ./scripts/setup_zipkin.sh && sleep 2m
     
     - name: Create helloworld container
       run: KUBECONFIG=/etc/kubernetes/admin.conf kn service create helloworld-go --image gcr.io/knative-samples/helloworld-go --env TARGET="vHive CRI test"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 ### Added
 - Support for MinIO S3 storage (non-replicated, non-distributed).
 - MicroVMs can now access the internet by default using custom host interface. (default route interface is used if no argument is provided)
-- Knative serving now can be tested separately from vHive. More info [here](https://github.com/ease-lab/vhive/wiki/Debugging-Knative-functions).
+- Knative serving now can be tested separately from vHive. More info [here](./docs/developers_guide.md#Testing-stock-Knative-images).
+- Zipkin support added for tracing Knative function call requests. More info [here](./docs/developers_guide.md#Knative-request-tracing)
 
 ### Changed
 

--- a/configs/.wordlist.txt
+++ b/configs/.wordlist.txt
@@ -132,6 +132,7 @@ Ipsum
 ISA
 ISCA
 ISPASS
+istioctl
 jekyll
 Jevdjic
 Joshi
@@ -165,6 +166,7 @@ Lim
 Linearizable
 linter
 LLC
+localhost
 Lorem
 Lotfi
 lsi
@@ -335,3 +337,5 @@ yaml
 yml
 YY
 Zhu
+zipkin
+Zipkin

--- a/docs/developers_guide.md
+++ b/docs/developers_guide.md
@@ -107,6 +107,12 @@ A test that is integrated with vHive-CRI orchestrator via a programmatic interfa
 allows to analyze latency breakdown of boot-based and snapshot cold starts,
 using detailed latency and memory footprint metrics.
 
+## Knative request tracing
+Knative function call requests can now be traced & visualized using [zipkin](https://zipkin.io/). Zipkin is a distributed tracing system featuring easy collection and lookup of tracing data. Checkout [this](https://www.scalyr.com/blog/zipkin-tutorial-distributed-tracing/) for a quickstart guide.
+
+* Once the zipkin container is running, start the dashboard using `istioctl dashboard zipkin`.
+* To access requests remotely, run `ssh -L 9411:127.0.0.1:9411 <Host_IP>` for port forwarding.
+* Go to your browser and enter [localhost:9411](http://localhost:9411) for the dashboard.
 
 ## Dependencies and binaries
 

--- a/scripts/cluster/setup_master_node.sh
+++ b/scripts/cluster/setup_master_node.sh
@@ -41,8 +41,11 @@ kubectl create secret generic -n metallb-system memberlist --from-literal=secret
 kubectl apply -f $ROOT/configs/metallb/metallb-configmap.yaml
 
 # istio
+cd $ROOT
 curl -L https://istio.io/downloadIstio | ISTIO_VERSION=1.7.1 TARGET_ARCH=x86_64 sh -
-./istio-1.7.1/bin/istioctl install -f $ROOT/configs/istio/istio-minimal-operator.yaml
+export PATH=$PATH:$ROOT/istio-1.7.1/bin
+sudo sh -c  "echo 'export PATH=$PATH:$ROOT/istio-1.7.1/bin' >> /etc/profile"
+istioctl install -f $ROOT/configs/istio/istio-minimal-operator.yaml
 
 # Install KNative in the cluster
 if [ "$STOCK_CONTAINERD" == "stock-only" ]; then


### PR DESCRIPTION
Once the cluster is booted, run `istioctl dashboard zipkin` to start the [zipkin](https://zipkin.io/) dashboard.

- To monitor requests remotely, run `ssh -L 9411:127.0.0.1:9411 <Host_IP>` for port forwarding.
- Open your browser and enter [localhost:9411](http://localhost:9411) for the dashboard.

Screenshots:
![image](https://user-images.githubusercontent.com/20225226/109794303-ba925900-7c3b-11eb-9a36-f92d9f960d89.png)
![image](https://user-images.githubusercontent.com/20225226/109794138-920a5f00-7c3b-11eb-92f5-bc1eb5be630d.png)



Signed-off-by: Shyam Jesal <s.jesalpura@gmail.com>