### PR TITLE
Fix binding policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - added support for MinIO object store. More info [here](./docs/developers_guide.md#MinIO-S3-service)
 - Added an automated tail-latency-aware profiler that collects the metrics for [TopDown](https://ieeexplore.ieee.org/document/6844459) characterization from Intel.
 - [alpha] Added knative eventing support using In-Memory Channel and MT-Channel-broker. Integration tests missing and Apache Kafka support coming soon.
+- [beta] Added an automated tail-latency-aware profiler that collects the metrics for [TopDown](https://ieeexplore.ieee.org/document/6844459) characterization from Intel.
 
 ### Changed
 

--- a/profile/profiler.go
+++ b/profile/profiler.go
@@ -83,6 +83,7 @@ func NewProfiler(executionTime float64, printInterval uint64, vmNum, level int, 
 		profiler.cmd.Args = append(profiler.cmd.Args, "--core", core)
 	} else {
 		if socket > -1 {
+			// monitor the input socket only
 			profiler.cmd.Args = append(profiler.cmd.Args, "--core", "S"+strconv.Itoa(socket))
 		}
 		// hide idle CPUs that are <50% of busiest.
@@ -431,7 +432,7 @@ func (c *CPUInfo) GetSibling(processor int) (int, error) {
 
 	core := c.sockets[proc.socket].cores[proc.core]
 	if len(core.processors) == 1 {
-		return -1, nil
+		return -1, errors.New("processor does not have a sibling")
 	}
 
 	if core.processors[0] == processor {
@@ -445,7 +446,7 @@ func (c *CPUInfo) GetSibling(processor int) (int, error) {
 func (c *CPUInfo) SocketCPUs(socket int) ([]int, error) {
 	var result []int
 	if socket >= len(c.sockets) || socket < 0 {
-		return nil, errors.New("socket ID is larger than the number of sockets")
+		return nil, errors.New("socket ID is out of bound")
 	}
 
 	for _, core := range c.sockets[socket].cores {

--- a/profile/profiler.go
+++ b/profile/profiler.go
@@ -81,8 +81,8 @@ func NewProfiler(executionTime float64, printInterval uint64, level int, nodes, 
 		}
 		profiler.cmd.Args = append(profiler.cmd.Args, "--core", core)
 	} else {
+		// monitor the input socket only. the socket value should be negative if profiler measures globally.
 		if socket > -1 {
-			// monitor the input socket only
 			profiler.cmd.Args = append(profiler.cmd.Args, "--core", "S"+strconv.Itoa(socket))
 		}
 		// hide idle CPUs that are <50% of busiest.
@@ -425,6 +425,7 @@ func (c *CPUInfo) GetSibling(processor int) (int, error) {
 	}
 
 	core := c.sockets[proc.socket].cores[proc.core]
+	// check if the core has two logical processors
 	if len(core.processors) == 1 {
 		return -1, errors.New("processor does not have a sibling")
 	}

--- a/profile/profiler_test.go
+++ b/profile/profiler_test.go
@@ -50,7 +50,7 @@ func TestReadPerfData(t *testing.T) {
 		}
 	)
 
-	p, err := NewProfiler(0, 100, 0, 1, "", fileName, -1, -1)
+	p, err := NewProfiler(0, 100, 1, "", fileName, -1, -1)
 	require.NoError(t, err, "Cannot create a profiler instance")
 
 	type testCase struct {
@@ -83,17 +83,17 @@ func TestReadPerfData(t *testing.T) {
 func TestProfilerRun(t *testing.T) {
 	fileName := "testFile"
 
-	p, err := NewProfiler(-1, 100, 0, 1, "", fileName, -1, -1)
+	p, err := NewProfiler(-1, 100, 1, "", fileName, -1, -1)
 	require.NoError(t, err, "Cannot create a profiler instance")
 	err = p.Run()
 	require.EqualError(t, err, "profiler execution time is less than 0s", "Failed running profiler")
 
-	p, err = NewProfiler(0, 1, 0, 1, "", fileName, -1, -1)
+	p, err = NewProfiler(0, 1, 1, "", fileName, -1, -1)
 	require.NoError(t, err, "Cannot create a profiler instance")
 	err = p.Run()
 	require.EqualError(t, err, "profiler print interval is less than 10ms", "Failed running profiler")
 
-	p, err = NewProfiler(0, 100, 0, 1, "", fileName, -1, -1)
+	p, err = NewProfiler(0, 100, 1, "", fileName, -1, -1)
 	require.NoError(t, err, "Cannot create a profiler instance")
 	err = p.Run()
 	require.NoError(t, err, "profiler run returned error: %v.", err)
@@ -114,7 +114,8 @@ func createData() error {
 		"0.503247704,C0,Retiring,97,% Slots <,,,0.0,3.99,,Y",
 		"1.503247704,C1,Frontend_Bound,3,% Slots <,,,0.0,3.99,,Y",
 		"1.503247704,C1,Backend_Bound,4,% Slots,,,0.0,3.99,<==,Y",
-		"1.503247704,C1,Retiring,93,% Slots,,,0.0,3.99,<==,Y"}
+		"1.503247704,C1,Retiring,93,% Slots,,,0.0,3.99,<==,Y",
+		"#..."}
 
 	for _, line := range lines {
 		_, err := f.WriteString(line + "\n")

--- a/profile/profiler_test.go
+++ b/profile/profiler_test.go
@@ -37,13 +37,16 @@ func TestReadPerfData(t *testing.T) {
 		result   = []map[string]float64{
 			{
 				"Frontend_Bound": 2,
-				"Backend_Bound":  3},
+				"Backend_Bound":  3,
+				"Retiring":       95},
 			{
 				"Frontend_Bound": 1,
-				"Backend_Bound":  2},
+				"Backend_Bound":  2,
+				"Retiring":       97},
 			{
 				"Frontend_Bound": 3,
-				"Backend_Bound":  4},
+				"Backend_Bound":  4,
+				"Retiring":       93},
 		}
 	)
 
@@ -108,8 +111,10 @@ func createData() error {
 	lines := []string{"Timestamp,CPUs,Area,Value,Unit,Description,Sample,Stddev,Multiplex,Bottleneck,Idle",
 		"0.503247704,C0,Frontend_Bound,1,% Slots <,,,0.0,3.99,,Y",
 		"0.503247704,C0,Backend_Bound,2,% Slots <,,,0.0,3.99,,Y",
+		"0.503247704,C0,Retiring,97,% Slots <,,,0.0,3.99,,Y",
 		"1.503247704,C1,Frontend_Bound,3,% Slots <,,,0.0,3.99,,Y",
-		"1.503247704,C1,Backend_Bound,4,% Slots,,,0.0,3.99,<==,Y"}
+		"1.503247704,C1,Backend_Bound,4,% Slots,,,0.0,3.99,<==,Y",
+		"1.503247704,C1,Retiring,93,% Slots,,,0.0,3.99,<==,Y"}
 
 	for _, line := range lines {
 		_, err := f.WriteString(line + "\n")

--- a/profile/profiler_test.go
+++ b/profile/profiler_test.go
@@ -47,7 +47,7 @@ func TestReadPerfData(t *testing.T) {
 		}
 	)
 
-	p, err := NewProfiler(0, 100, 0, 1, "", fileName, -1)
+	p, err := NewProfiler(0, 100, 0, 1, "", fileName, -1, -1)
 	require.NoError(t, err, "Cannot create a profiler instance")
 
 	type testCase struct {
@@ -80,17 +80,17 @@ func TestReadPerfData(t *testing.T) {
 func TestProfilerRun(t *testing.T) {
 	fileName := "testFile"
 
-	p, err := NewProfiler(-1, 100, 0, 1, "", fileName, -1)
+	p, err := NewProfiler(-1, 100, 0, 1, "", fileName, -1, -1)
 	require.NoError(t, err, "Cannot create a profiler instance")
 	err = p.Run()
 	require.EqualError(t, err, "profiler execution time is less than 0s", "Failed running profiler")
 
-	p, err = NewProfiler(0, 1, 0, 1, "", fileName, -1)
+	p, err = NewProfiler(0, 1, 0, 1, "", fileName, -1, -1)
 	require.NoError(t, err, "Cannot create a profiler instance")
 	err = p.Run()
 	require.EqualError(t, err, "profiler print interval is less than 10ms", "Failed running profiler")
 
-	p, err = NewProfiler(0, 100, 0, 1, "", fileName, -1)
+	p, err = NewProfiler(0, 100, 0, 1, "", fileName, -1, -1)
 	require.NoError(t, err, "Cannot create a profiler instance")
 	err = p.Run()
 	require.NoError(t, err, "profiler run returned error: %v.", err)


### PR DESCRIPTION
- VMs can use all logical cores including the profiling one
- fix getting sibling of a processor error when SMT is off
- minor fix log level and argument check

Signed-off-by: NiuJ1ao <26167136+NiuJ1ao@users.noreply.github.com>