### PR TITLE
Updated the firecracker and jailer binaries to v0.24

### DIFF
--- a/.github/workflows/cri_tests.yml
+++ b/.github/workflows/cri_tests.yml
@@ -141,6 +141,8 @@ jobs:
       run: sleep 1m && make -C ./function-images/tests/save_load_minio local
 
     - name: Test minio
+      env:
+        KUBECONFIG: /etc/kubernetes/admin.conf
       run: ./function-images/tests/save_load_minio/scripts/run_minio_k8s.sh
     
     - name: Cleaning

--- a/bin/firecracker
+++ b/bin/firecracker
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0d4d8fbefdb0e6a196ea59ca528e57040c642a55d28bb73822c8d9e5703eadb2
-size 3226384
+oid sha256:84c660361f5d90809b41c6be7a61c30e92755ff3780de2378692663c992bca3c
+size 3678288

--- a/bin/jailer
+++ b/bin/jailer
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2dab38ab030270845b910dde4906256aa324b86e80fe848e0126b106bffcc8b9
-size 2568392
+oid sha256:2376bc8035f90b61e662d79e74a0f38ab3053dfdcc2eeed671f02cef884783b9
+size 2828176


### PR DESCRIPTION
- after rebasing the upf branch atop of upstream (v0.24)
- fixed sporadic errors in minio due to missing config file by manually setting KUBECONFIG variable

Signed-off-by: Dmitrii Ustiugov <dmitrii.ustiugov@epfl.ch>