### PR TITLE
Add gettext dependency

### DIFF
--- a/scripts/github_runner/Dockerfile.cri_dev_env
+++ b/scripts/github_runner/Dockerfile.cri_dev_env
@@ -44,6 +44,7 @@ RUN apt-get update && \
     socat \
     util-linux \
     ipvsadm \
+    gettext-base \
     tmux vim && \
     sudo wget -O /usr/local/bin/kn -c "https://github.com/knative/client/releases/download/v0.20.0/kn-linux-amd64" && \
     sudo chmod +x /usr/local/bin/kn && \

--- a/scripts/setup_system.sh
+++ b/scripts/setup_system.sh
@@ -43,6 +43,7 @@ sudo apt-get -y install \
     dmsetup \
     gnupg-agent \
     software-properties-common \
+    gettext-base \
     skopeo >> /dev/null
 
 # stack size, # of open files, # of pids


### PR DESCRIPTION
Gettext was not installed causing [the master node setup to fail](https://github.com/ease-lab/vhive/runs/2169277370?check_suite_focus=true#step:7:273) during the tests.