### PR TITLE
make CRI test logs persistent

### DIFF
--- a/.github/workflows/cri_test.yml
+++ b/.github/workflows/cri_test.yml
@@ -23,6 +23,14 @@ jobs:
     runs-on: [self-hosted, cri]
     
     steps:
+
+    - name: Host Info
+      env:
+          GITHUB_RUN_ID: ${{ github.run_id }}-${{ github.run_number }}
+      run: |
+        echo $HOSTNAME
+        echo $GITHUB_RUN_ID
+
     - name: Setup TMPDIR
       run: mkdir -p $HOME/tmp
 
@@ -52,6 +60,7 @@ jobs:
           TMPDIR: /root/tmp/
           GOCACHE: /root/tmp/gocache
           GOPATH: /root/tmp/gopath
+          GITHUB_RUN_ID: ${{ github.run_id }}-${{ github.run_number }}
       run: make test-cri
     
     - name: Cleaning

--- a/cri/Makefile
+++ b/cri/Makefile
@@ -21,14 +21,14 @@
 # SOFTWARE.
 
 EXTRAGOARGS:=-v -race -cover
-CTRDLOGDIR:=/tmp/ctrd-logs
+CTRDLOGDIR:=/tmp/ctrd-logs/${GITHUB_RUN_ID}
 test:
 	sudo mkdir -p -m777 -p $(CTRDLOGDIR)
 	sudo containerd 1>$(CTRDLOGDIR)/ctrd.out 2>$(CTRDLOGDIR)/ctrd.err &
 	sleep 1s
 	sudo /usr/local/bin/firecracker-containerd --config /etc/firecracker-containerd/config.toml 1>$(CTRDLOGDIR)/fccd.out 2>$(CTRDLOGDIR)/fccd.err &
 	sleep 1s
-	sudo ./../vhive 1>$(CTRDLOGDIR)/orch.out 2>$(CTRDLOGDIR)/orch.err &
+	sudo ./../vhive -dbg 1>$(CTRDLOGDIR)/orch.out 2>$(CTRDLOGDIR)/orch.err &
 	sleep 1s
 
 	./../scripts/cluster/create_one_node_cluster.sh

--- a/scripts/github_runner/start_runners.sh
+++ b/scripts/github_runner/start_runners.sh
@@ -61,7 +61,7 @@ case "$4" in
     do
         # create access token as mentioned here (https://github.com/myoung34/docker-github-actions-runner#create-github-personal-access-token)
         CONTAINERID=$(docker run -d --restart always --privileged \
-            --name "integration_test-github_runner-${number}" \
+            --name "integration_test-github_runner-${HOSTNAME}-${number}" \
             -e REPO_URL="${_SHORT_URL}" \
             -e ACCESS_TOKEN="${ACCESS_TOKEN}" \
             -e LABELS="${3}" \
@@ -79,12 +79,12 @@ case "$4" in
     fi
     for number in $(seq 1 $1)
     do
-        kind create cluster --image vhiveease/cri_test_runner --name "cri-test-github-runner-${number}"
+        kind create cluster --image vhiveease/cri_test_runner --name "cri-test-github-runner-${HOSTNAME}-${number}"
         sleep 2m
         docker exec -it \
             -e RUNNER_ALLOW_RUNASROOT=1 \
             -w /root/actions-runner \
-            "cri-test-github-runner-${number}-control-plane" \
+            "cri-test-github-runner-${HOSTNAME}-${number}-control-plane" \
             ./config.sh \
                 --url "${_SHORT_URL}" \
                 --token "${RUNNER_TOKEN}" \
@@ -95,10 +95,10 @@ case "$4" in
                 --replace
         sleep 20s
         docker exec -it \
-            "cri-test-github-runner-${number}-control-plane" \
+            "cri-test-github-runner-${HOSTNAME}-${number}-control-plane" \
             systemctl daemon-reload
         docker exec -it \
-            "cri-test-github-runner-${number}-control-plane" \
+            "cri-test-github-runner-${HOSTNAME}-${number}-control-plane" \
             systemctl enable connect_github_runner --now
     done
     ;;


### PR DESCRIPTION
- [x] CRI test
- [ ] Minio test
- [ ] Stock containerd test

```
Run echo $HOSTNAME
cri-test-github-runner-iccluster128-1-control-plane
691114828
```

The logs are stored on iccluster128 at /tmp/ctrd-logs/691114828/

Signed-off-by: Shyam Jesal <s.jesalpura@gmail.com>