### PR TITLE
Rename master to main in our CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,12 +2,12 @@ name: vHive build tests
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
     paths-ignore:
     - 'docs/**'
     - '**.md'
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
     paths-ignore:
     - 'docs/**'
     - '**.md'

--- a/.github/workflows/build_docker_images.yml
+++ b/.github/workflows/build_docker_images.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
       with:
-        ref: master
+        ref: main
     - name: docker build images
     # Consecutive COPY commands in Dockerfile fail on github runners
     # Added "DOCKER_BUILDKIT=1" as a temporary fix
@@ -37,7 +37,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
       with:
-        ref: master
+        ref: main
     - name: pull binaries
       run: |
         git lfs pull

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,10 +13,10 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ master ]
+    branches: [ main ]
   workflow_dispatch:
   schedule:
     - cron: '40 13 * * 2'

--- a/.github/workflows/cri_minio_test.yml
+++ b/.github/workflows/cri_minio_test.yml
@@ -2,12 +2,12 @@ name: MinIO tests
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
     paths-ignore:
     - 'docs/**'
     - '**.md'
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
     paths-ignore:
     - 'docs/**'
     - '**.md'

--- a/.github/workflows/cri_stock_containerd_test.yml
+++ b/.github/workflows/cri_stock_containerd_test.yml
@@ -2,12 +2,12 @@ name: stock Containerd CRI tests
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
     paths-ignore:
     - 'docs/**'
     - '**.md'
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
     paths-ignore:
     - 'docs/**'
     - '**.md'

--- a/.github/workflows/cri_test.yml
+++ b/.github/workflows/cri_test.yml
@@ -2,12 +2,12 @@ name: vHive CRI tests
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
     paths-ignore:
     - 'docs/**'
     - '**.md'
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
     paths-ignore:
     - 'docs/**'
     - '**.md'

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -2,12 +2,12 @@ name: vHive integration tests
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
     paths-ignore:
     - 'docs/**'
     - '**.md'
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
     paths-ignore:
     - 'docs/**'
     - '**.md'

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -1,9 +1,9 @@
 name: Linters
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   build:

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -2,12 +2,12 @@ name: vHive unit tests
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
     paths-ignore:
     - 'docs/**'
     - '**.md'
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
     paths-ignore:
     - 'docs/**'
     - '**.md'


### PR DESCRIPTION
We endorse the community's efforts to move to inclusive language usage. This PR renames the references to the master branch.

Signed-off-by: Dmitrii Ustiugov <dmitrii.ustiugov@epfl.ch>