### PR TITLE
Add CRI tests to nightly

### DIFF
--- a/.github/workflows/cri_minio_test.yml
+++ b/.github/workflows/cri_minio_test.yml
@@ -1,17 +1,9 @@
 name: MinIO tests
 
 on:
-  push:
-    branches: [ main ]
-    paths-ignore:
-    - 'docs/**'
-    - '**.md'
-  pull_request:
-    branches: [ main ]
-    paths-ignore:
-    - 'docs/**'
-    - '**.md'
   workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * *'
 
 env:
   GOOS: linux

--- a/.github/workflows/cri_stock_containerd_test.yml
+++ b/.github/workflows/cri_stock_containerd_test.yml
@@ -1,17 +1,9 @@
 name: stock Containerd CRI tests
 
 on:
-  push:
-    branches: [ main ]
-    paths-ignore:
-    - 'docs/**'
-    - '**.md'
-  pull_request:
-    branches: [ main ]
-    paths-ignore:
-    - 'docs/**'
-    - '**.md'
   workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * *'
 
 env:
   GOOS: linux

--- a/.github/workflows/cri_test.yml
+++ b/.github/workflows/cri_test.yml
@@ -21,12 +21,13 @@ jobs:
   cri-tests:
     name: CRI tests
     runs-on: [self-hosted, cri]
-    
+
     steps:
 
     - name: Host Info
       env:
           GITHUB_RUN_ID: ${{ github.run_id }}
+          GITHUB_RUNNER_VHIVE_ARGS: "-dbg"
       run: |
         echo $HOSTNAME
         echo $GITHUB_RUN_ID
@@ -70,7 +71,7 @@ jobs:
         name: ctrd-logs
         path: |
           /tmp/ctrd-logs/${{ github.run_id }}
-    
+
     - name: Cleaning
       if: ${{ always() }}
       run: ./scripts/github_runner/clean_cri_runner.sh

--- a/.github/workflows/cri_test.yml
+++ b/.github/workflows/cri_test.yml
@@ -27,7 +27,6 @@ jobs:
     - name: Host Info
       env:
           GITHUB_RUN_ID: ${{ github.run_id }}
-          GITHUB_RUNNER_VHIVE_ARGS: "-dbg"
       run: |
         echo $HOSTNAME
         echo $GITHUB_RUN_ID
@@ -62,6 +61,7 @@ jobs:
           GOCACHE: /root/tmp/gocache
           GOPATH: /root/tmp/gopath
           GITHUB_RUN_ID: ${{ github.run_id }}
+          GITHUB_VHIVE_ARGS: "-dbg"
       run: make test-cri
 
     - name: Archive log artifacts

--- a/.github/workflows/nightly_tests.yml
+++ b/.github/workflows/nightly_tests.yml
@@ -56,7 +56,6 @@ jobs:
     - name: Host Info
       env:
           GITHUB_RUN_ID: ${{ github.run_id }}
-          GITHUB_RUNNER_VHIVE_ARGS: $${{ matrix.vhive_args }}
       run: |
         echo $HOSTNAME
         echo $GITHUB_RUN_ID
@@ -91,7 +90,10 @@ jobs:
           GOCACHE: /root/tmp/gocache
           GOPATH: /root/tmp/gopath
           GITHUB_RUN_ID: ${{ github.run_id }}
-      run: make test-cri
+          GITHUB_VHIVE_ARGS: $${{ matrix.vhive_args }}
+      run: |
+        echo vHive args are $GITHUB_VHIVE_ARGS
+        make test-cri
 
     - name: Archive log artifacts
       if: ${{ always() }}

--- a/.github/workflows/nightly_tests.yml
+++ b/.github/workflows/nightly_tests.yml
@@ -29,7 +29,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         lfs: true
-    
+
     - name: Pull binaries
       run: ./scripts/setup_firecracker_containerd.sh
 
@@ -42,3 +42,65 @@ jobs:
     - name: Cleaning
       if: ${{ always() }}
       run: ./scripts/clean_fcctr.sh
+
+  cri-tests:
+    name: CRI tests (nightly)
+    runs-on: [self-hosted, cri]
+    strategy:
+      fail-fast: false
+      matrix:
+        vhive_args: ["-dbg", "-dbg -snapshots", "-dbg -snapshots -upf"]
+
+    steps:
+
+    - name: Host Info
+      env:
+          GITHUB_RUN_ID: ${{ github.run_id }}
+          GITHUB_RUNNER_VHIVE_ARGS: $${{ matrix.vhive_args }}
+      run: |
+        echo $HOSTNAME
+        echo $GITHUB_RUN_ID
+
+    - name: Setup TMPDIR
+      run: mkdir -p $HOME/tmp
+
+    - name: Set up Go 1.15
+      env:
+          GOROOT: $HOME/go
+          GOCACHE: /root/tmp/gocache
+          GOPATH: /root/tmp/gopath
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.15
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v2
+
+    - name: Setup firecracker-containerd
+      run: ./scripts/setup_firecracker_containerd.sh
+
+    - name: Build
+      env:
+          GOCACHE: /root/tmp/gocache
+          GOPATH: /root/tmp/gopath
+      run: go build
+
+    - name: Run vHive CRI tests
+      env:
+          TMPDIR: /root/tmp/
+          GOCACHE: /root/tmp/gocache
+          GOPATH: /root/tmp/gopath
+          GITHUB_RUN_ID: ${{ github.run_id }}
+      run: make test-cri
+
+    - name: Archive log artifacts
+      if: ${{ always() }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: ctrd-logs
+        path: |
+          /tmp/ctrd-logs/${{ github.run_id }}
+
+    - name: Cleaning
+      if: ${{ always() }}
+      run: ./scripts/github_runner/clean_cri_runner.sh

--- a/configs/.wordlist.txt
+++ b/configs/.wordlist.txt
@@ -73,6 +73,7 @@ datacenter
 Datacenter
 david
 DBG
+dbg
 DCNs
 De
 debian

--- a/cri/Makefile
+++ b/cri/Makefile
@@ -21,7 +21,6 @@
 # SOFTWARE.
 
 EXTRAGOARGS:=-v -race -cover
-CTRDLOGDIR:=/tmp/ctrd-logs/${GITHUB_RUN_ID}
 test:
 
 	./../scripts/cloudlab/start_onenode_vhive_cluster.sh

--- a/docs/quickstart_guide.md
+++ b/docs/quickstart_guide.md
@@ -138,7 +138,8 @@ source /etc/profile && go build && sudo ./vhive
 This script stops the existing cluster if any, cleans up and then starts a fresh single-node cluster.
 
 ```bash
-scripts/cloudlab/start_onenode_vhive_cluster.sh <folder to store logs>
+export GITHUB_RUNNER_VHIVE_ARGS="[-dbg] [-snapshots] [-upf]" # specify if to enable debug logs; cold starts: snapshots, REAP snapshots (optional)
+scripts/cloudlab/start_onenode_vhive_cluster.sh
 ```
 
 ## CloudLab deployment notes

--- a/docs/quickstart_guide.md
+++ b/docs/quickstart_guide.md
@@ -138,7 +138,7 @@ source /etc/profile && go build && sudo ./vhive
 This script stops the existing cluster if any, cleans up and then starts a fresh single-node cluster.
 
 ```bash
-export GITHUB_RUNNER_VHIVE_ARGS="[-dbg] [-snapshots] [-upf]" # specify if to enable debug logs; cold starts: snapshots, REAP snapshots (optional)
+export GITHUB_VHIVE_ARGS="[-dbg] [-snapshots] [-upf]" # specify if to enable debug logs; cold starts: snapshots, REAP snapshots (optional)
 scripts/cloudlab/start_onenode_vhive_cluster.sh
 ```
 

--- a/scripts/clean_fcctr.sh
+++ b/scripts/clean_fcctr.sh
@@ -66,9 +66,6 @@ fi
 echo Cleaning /var/lib/firecracker-containerd/*
 for d in containerd shim-base snapshotter; do sudo rm -rf /var/lib/firecracker-containerd/$d; done
 
-echo Creating a fresh devmapper
-source $DIR/create_devmapper.sh
-
 echo Cleaning /run/firecracker-containerd/*
 sudo rm -rf /run/firecracker-containerd/containerd.sock.ttrpc \
     /run/firecracker-containerd/io.containerd.runtime.v1.linux \
@@ -78,3 +75,5 @@ echo Cleaning CNI state, e.g., allocated addresses
 sudo rm /var/lib/cni/networks/fcnet*/last_reserved_ip.0 || echo clean already
 sudo rm /var/lib/cni/networks/fcnet*/19* || echo clean already
 
+echo Creating a fresh devmapper
+source $DIR/create_devmapper.sh

--- a/scripts/cloudlab/start_onenode_vhive_cluster.sh
+++ b/scripts/cloudlab/start_onenode_vhive_cluster.sh
@@ -46,8 +46,8 @@ echo Build vHive
 cd $ROOT
 source /etc/profile && go build
 
-echo Running vHive with \"${GITHUB_RUNNER_VHIVE_ARGS}\" arguments
-sudo ./vhive ${GITHUB_RUNNER_VHIVE_ARGS} && \
+echo Running vHive with \"${GITHUB_VHIVE_ARGS}\" arguments
+sudo ./vhive ${GITHUB_VHIVE_ARGS} && \
     1>$CTRDLOGDIR/orch.out 2>$CTRDLOGDIR/orch.err &
 sleep 1s
 

--- a/scripts/cloudlab/start_onenode_vhive_cluster.sh
+++ b/scripts/cloudlab/start_onenode_vhive_cluster.sh
@@ -37,9 +37,7 @@ sudo containerd 1>$CTRDLOGDIR/ctrd.out 2>$CTRDLOGDIR/ctrd.err &
 sleep 1s
 
 echo Run the firecracker-containerd daemon
-sudo /usr/local/bin/firecracker-containerd && \
-    --config /etc/firecracker-containerd/config.toml && \
-    1>$CTRDLOGDIR/fccd.out 2>$CTRDLOGDIR/fccd.err &
+sudo /usr/local/bin/firecracker-containerd --config /etc/firecracker-containerd/config.toml 1>$CTRDLOGDIR/fccd.out 2>$CTRDLOGDIR/fccd.err &
 sleep 1s
 
 echo Build vHive
@@ -47,8 +45,7 @@ cd $ROOT
 source /etc/profile && go build
 
 echo Running vHive with \"${GITHUB_VHIVE_ARGS}\" arguments
-sudo ./vhive ${GITHUB_VHIVE_ARGS} && \
-    1>$CTRDLOGDIR/orch.out 2>$CTRDLOGDIR/orch.err &
+sudo ./vhive ${GITHUB_VHIVE_ARGS} 1>$CTRDLOGDIR/orch.out 2>$CTRDLOGDIR/orch.err &
 sleep 1s
 
 $SCRIPTS/cluster/create_one_node_cluster.sh


### PR DESCRIPTION
* Added the CRI tests to nightly, checking modes w/ and w/o snapshots as well as REAP snapshots (`-upf`)
* Move stock Knative and MinIO tests to nightly, removing it from tests on push to a PR
* Refactored the script for (re)starting a vHive cluster
* Fixed the CRI cleaning script by removing the thinpool
* Adjusted the docs accordingly