### PR TITLE
Refactor CI env variables

### DIFF
--- a/.github/workflows/cri_minio_test.yml
+++ b/.github/workflows/cri_minio_test.yml
@@ -8,6 +8,10 @@ on:
 env:
   GOOS: linux
   GO111MODULE: on
+  TMPDIR: /root/tmp/
+  GOCACHE: /root/tmp/gocache
+  GOPATH: /root/tmp/gopath
+  GOROOT: $HOME/go
 
 jobs:
   minio-test:
@@ -16,13 +20,9 @@ jobs:
 
     steps:
     - name: Setup TMPDIR
-      run: mkdir -p $HOME/tmp
+      run: mkdir -p $TMPDIR
 
     - name: Set up Go 1.15
-      env:
-          GOROOT: $HOME/go
-          GOCACHE: /root/tmp/gocache
-          GOPATH: /root/tmp/gopath
       uses: actions/setup-go@v2
       with:
         go-version: 1.15
@@ -34,24 +34,15 @@ jobs:
       run: ./scripts/setup_firecracker_containerd.sh
 
     - name: Build
-      env:
-          GOCACHE: /root/tmp/gocache
-          GOPATH: /root/tmp/gopath
       run: go build
 
     - name: Start vHive cluster
       run: ./scripts/cloudlab/start_onenode_vhive_cluster.sh
 
     - name: modify $PATH
-      env:
-          GOCACHE: /root/tmp/gocache
-          GOPATH: /root/tmp/gopath
       run: echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
 
     - name: Setup minio
-      env:
-          GOCACHE: /root/tmp/gocache
-          GOPATH: /root/tmp/gopath
       run: sleep 1m && make -C ./function-images/tests/save_load_minio local
 
     - name: Test minio

--- a/.github/workflows/cri_stock_containerd_test.yml
+++ b/.github/workflows/cri_stock_containerd_test.yml
@@ -8,6 +8,7 @@ on:
 env:
   GOOS: linux
   GO111MODULE: on
+  TMPDIR: /root/tmp/
 
 jobs:
   stock-containerd-test:
@@ -16,7 +17,7 @@ jobs:
 
     steps:
     - name: Setup TMPDIR
-      run: mkdir -p $HOME/tmp
+      run: mkdir -p $TMPDIR
 
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2

--- a/.github/workflows/cri_test.yml
+++ b/.github/workflows/cri_test.yml
@@ -16,29 +16,29 @@ on:
 env:
   GOOS: linux
   GO111MODULE: on
+  TMPDIR: /root/tmp/
+  GOCACHE: /root/tmp/gocache
+  GOPATH: /root/tmp/gopath
 
 jobs:
   cri-tests:
     name: CRI tests
+    env:
+        GITHUB_RUN_ID: ${{ github.run_id }}
+        GITHUB_VHIVE_ARGS: "-dbg"
     runs-on: [self-hosted, cri]
 
     steps:
 
     - name: Host Info
-      env:
-          GITHUB_RUN_ID: ${{ github.run_id }}
       run: |
         echo $HOSTNAME
         echo $GITHUB_RUN_ID
 
     - name: Setup TMPDIR
-      run: mkdir -p $HOME/tmp
+      run: mkdir -p $TMPDIR
 
     - name: Set up Go 1.15
-      env:
-          GOROOT: $HOME/go
-          GOCACHE: /root/tmp/gocache
-          GOPATH: /root/tmp/gopath
       uses: actions/setup-go@v2
       with:
         go-version: 1.15
@@ -50,18 +50,9 @@ jobs:
       run: ./scripts/setup_firecracker_containerd.sh
 
     - name: Build
-      env:
-          GOCACHE: /root/tmp/gocache
-          GOPATH: /root/tmp/gopath
       run: go build
 
     - name: Run vHive CRI tests
-      env:
-          TMPDIR: /root/tmp/
-          GOCACHE: /root/tmp/gocache
-          GOPATH: /root/tmp/gopath
-          GITHUB_RUN_ID: ${{ github.run_id }}
-          GITHUB_VHIVE_ARGS: "-dbg"
       run: make test-cri
 
     - name: Archive log artifacts

--- a/.github/workflows/nightly_tests.yml
+++ b/.github/workflows/nightly_tests.yml
@@ -8,12 +8,19 @@ on:
 env:
   GOOS: linux
   GO111MODULE: on
+  TMPDIR: /root/tmp/
+  GOCACHE: /root/tmp/gocache
+  GOPATH: /root/tmp/gopath
+  GOROOT: $HOME/go
 
 jobs:
   integration-tests:
     name: Test all functions
     runs-on: [self-hosted, nightly, integ]
     steps:
+    - name: Setup TMPDIR
+      run: mkdir -p $TMPDIR
+
     - name: Set up Go 1.15
       uses: actions/setup-go@v2
       with:
@@ -50,24 +57,23 @@ jobs:
       fail-fast: false
       matrix:
         vhive_args: ["-dbg", "-dbg -snapshots", "-dbg -snapshots -upf"]
+    env:
+        GITHUB_RUN_ID: ${{ github.run_id }}
+        GITHUB_JOB: ${{ github.job }}
+        GITHUB_VHIVE_ARGS: ${{ matrix.vhive_args }}
 
     steps:
 
     - name: Host Info
-      env:
-          GITHUB_RUN_ID: ${{ github.run_id }}
       run: |
-        echo $HOSTNAME
-        echo $GITHUB_RUN_ID
+        echo HOSTNAME=$HOSTNAME
+        echo GITHUB_RUN_ID=$GITHUB_RUN_ID
+        echo GITHUB_JOB=$GITHUB_JOB
 
     - name: Setup TMPDIR
-      run: mkdir -p $HOME/tmp
+      run: mkdir -p $TMPDIR
 
     - name: Set up Go 1.15
-      env:
-          GOROOT: $HOME/go
-          GOCACHE: /root/tmp/gocache
-          GOPATH: /root/tmp/gopath
       uses: actions/setup-go@v2
       with:
         go-version: 1.15
@@ -79,18 +85,9 @@ jobs:
       run: ./scripts/setup_firecracker_containerd.sh
 
     - name: Build
-      env:
-          GOCACHE: /root/tmp/gocache
-          GOPATH: /root/tmp/gopath
       run: go build
 
     - name: Run vHive CRI tests
-      env:
-          TMPDIR: /root/tmp/
-          GOCACHE: /root/tmp/gocache
-          GOPATH: /root/tmp/gopath
-          GITHUB_RUN_ID: ${{ github.run_id }}
-          GITHUB_VHIVE_ARGS: $${{ matrix.vhive_args }}
       run: |
         echo vHive args are $GITHUB_VHIVE_ARGS
         make test-cri
@@ -99,7 +96,7 @@ jobs:
       if: ${{ always() }}
       uses: actions/upload-artifact@v2
       with:
-        name: ctrd-logs
+        name: ${{ github.job }}-${{ matrix.vhive_args }}-ctrd-logs
         path: |
           /tmp/ctrd-logs/${{ github.run_id }}
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![build](https://github.com/ease-lab/vhive/workflows/vHive%20build%20tests/badge.svg)](https://github.com/ease-lab/vhive/actions)
 [![Unit Tests](https://github.com/ease-lab/vhive/workflows/vHive%20unit%20tests/badge.svg)](https://github.com/ease-lab/vhive/actions)
 [![Integration Tests](https://github.com/ease-lab/vhive/workflows/vHive%20integration%20tests/badge.svg)](https://github.com/ease-lab/vhive/actions)
-[![Nightly Tests](https://github.com/ease-lab/vhive/workflows/vHive%20nightly%20integration%20tests/badge.svg)](https://github.com/ease-lab/vhive/actions)
+[![vHive CRI tests](https://github.com/ease-lab/vhive/actions/workflows/cri_test.yml/badge.svg)](https://github.com/ease-lab/vhive/actions/workflows/cri_test.yml)
 [![Go Report Card](https://goreportcard.com/badge/github.com/ease-lab/vhive)](https://goreportcard.com/report/github.com/ease-lab/vhive)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 


### PR DESCRIPTION
* move duplicated env variable declarations to the workflow and job levels
* add job_id to nightly CRI logs to avoid parallel jobs overwrite each other's artifacts

Signed-off-by: Dmitrii Ustiugov <dmitrii.ustiugov@epfl.ch>