### PR TITLE
Replaced xip.io to nip.io.

### DIFF
--- a/.github/workflows/cri_stock_containerd_test.yml
+++ b/.github/workflows/cri_stock_containerd_test.yml
@@ -36,6 +36,9 @@ jobs:
     - name: Create helloworld container
       run: KUBECONFIG=/etc/kubernetes/admin.conf kn service create helloworld-go --image gcr.io/knative-samples/helloworld-go --env TARGET="vHive CRI test"
 
+    - name: Invoke the deployed function
+      run: curl http://helloworld-go.default.192.168.1.240.nip.io
+
     - name: Cleaning
       if: ${{ always() }}
       run: ./scripts/github_runner/clean_cri_runner.sh stock-only

--- a/configs/knative_yamls/serving-default-domain.yaml
+++ b/configs/knative_yamls/serving-default-domain.yaml
@@ -34,7 +34,7 @@ spec:
           # This is the Go import path for the binary that is containerized
           # and substituted here.
           image: docker.io/vhiveease/default-domain-dd6f55160290a90018ba318b624be12e:998c8975f56b3b45059fd709d3776062b51cb1aa84921d4d7a85c0315d9cd0f0
-          args: ["-magic-dns=xip.io"]
+          args: ["-magic-dns=nip.io"]
           ports:
             - name: http
               containerPort: 8080

--- a/cri/cri_test.go
+++ b/cri/cri_test.go
@@ -41,7 +41,7 @@ import (
 
 var (
 	coord         *coordinator
-	gatewayURL    = flag.String("gatewayURL", "192.168.1.240.xip.io", "URL of the gateway")
+	gatewayURL    = flag.String("gatewayURL", "192.168.1.240.nip.io", "URL of the gateway")
 	namespaceName = flag.String("namespace", "default", "name of namespace in which services exists")
 )
 

--- a/examples/deployer/client.go
+++ b/examples/deployer/client.go
@@ -36,7 +36,7 @@ import (
 )
 
 var (
-	gatewayURL    = flag.String("gatewayURL", "192.168.1.240.xip.io", "URL of the gateway")
+	gatewayURL    = flag.String("gatewayURL", "192.168.1.240.nip.io", "URL of the gateway")
 	namespaceName = flag.String("namespace", "default", "name of namespace in which services exists")
 )
 

--- a/function-images/tests/save_load_minio/scripts/run_minio_k8s.sh
+++ b/function-images/tests/save_load_minio/scripts/run_minio_k8s.sh
@@ -52,5 +52,5 @@ kn service apply \
     --concurrency-target 1 --scale=1
 
 $DIR/../bins/client -d \
-    --addr="minio-test.default.192.168.1.240.xip.io:80" \
+    --addr="minio-test.default.192.168.1.240.nip.io:80" \
     --minioAddr="10.96.0.46:9000" -size=1024

--- a/scripts/cluster/setup_master_node.sh
+++ b/scripts/cluster/setup_master_node.sh
@@ -67,7 +67,7 @@ kubectl apply --filename $ROOT/configs/registry/repository-update-hosts.yaml
 # magic DNS
 kubectl apply --filename $ROOT/configs/knative_yamls/serving-default-domain.yaml
 
-kubectl apply --filename https://github.com/knative/net-istio/releases/download/v0.19.0/release.yaml
+kubectl apply --filename https://github.com/knative/net-istio/releases/download/$KNATIVE_VERSION/release.yaml
 
 # install knative eventing
 kubectl apply --filename https://github.com/knative/eventing/releases/download/$KNATIVE_VERSION/eventing-crds.yaml


### PR DESCRIPTION
This PR fixes #225:

- Replaced xip.io with nip.io as the DNS server for function name resolution. 
- Fixed the version of the net-istio manifest in the setup script (used to be v0.19.0).

Signed-off-by: Shyam Jesal <s.jesalpura@gmail.com>