### PR TITLE
Tidy logging messages in examples/{deployer,invoker}

### DIFF
--- a/examples/deployer/client.go
+++ b/examples/deployer/client.go
@@ -73,7 +73,7 @@ type functionType struct {
 }
 
 func getFuncSlice(file string) []functionType {
-	log.Debugf("Opening JSON file with functions: %s\n", file)
+	log.Debug("Opening JSON file with functions: ", file)
 	jsonFile, err := os.Open(file)
 	if err != nil {
 		log.Fatal(err)
@@ -138,14 +138,14 @@ func deployFunction(funcName, filePath string) {
 		log.Warnf("Failed to deploy function %s, %s: %v\n%s\n", funcName, filePath, err, stdoutStderr)
 	}
 
-	log.Info("Deployed function", funcName)
+	log.Info("Deployed function ", funcName)
 }
 
 func writeURLs(filePath string, urls []string) {
 	file, err := os.OpenFile(filePath, os.O_CREATE|os.O_WRONLY, 0644)
 
 	if err != nil {
-		log.Fatalf("failed creating file: %s", err)
+		log.Fatal("Failed creating file: ", err)
 	}
 
 	datawriter := bufio.NewWriter(file)

--- a/examples/invoker/client.go
+++ b/examples/invoker/client.go
@@ -51,11 +51,11 @@ func main() {
 
 	flag.Parse()
 
-	log.Infof("Reading the URLs from the file: %s", *urlFile)
+	log.Info("Reading the URLs from the file: ", *urlFile)
 
 	urls, err := readLines(*urlFile)
 	if err != nil {
-		log.Fatal("Failed to read the URL files:", err)
+		log.Fatal("Failed to read the URL files: ", err)
 	}
 
 	realRPS := runBenchmark(urls, *runDuration, *rps)
@@ -90,8 +90,8 @@ func runBenchmark(urls []string, runDuration, targetRPS int) (realRPS float64) {
 		case <-timeout:
 			duration := time.Since(start).Seconds()
 			realRPS = float64(completed) / duration
-			log.Infof("Issued / completed requests : %d, %d", issued, completed)
-			log.Infof("Real / target RPS : %.2f / %v", realRPS, targetRPS)
+			log.Infof("Issued / completed requests: %d, %d", issued, completed)
+			log.Infof("Real / target RPS: %.2f / %v", realRPS, targetRPS)
 
 			log.Println("Benchmark finished!")
 
@@ -155,12 +155,12 @@ func writeLatencies(rps float64, latencyOutputFile string) {
 	defer latSlice.Unlock()
 
 	fileName := fmt.Sprintf("rps%.2f_%s", rps, latencyOutputFile)
-	log.Infof("The measured latencies are saved in %s.", fileName)
+	log.Info("The measured latencies are saved in ", fileName)
 
 	file, err := os.OpenFile(fileName, os.O_CREATE|os.O_WRONLY, 0644)
 
 	if err != nil {
-		log.Fatalf("failed creating file: %s", err)
+		log.Fatal("Failed creating file: ", err)
 	}
 
 	datawriter := bufio.NewWriter(file)


### PR DESCRIPTION
Rules:
- If a log.xxxF() ends with a simple (e.g., `%s`) formatter, use log.xxx() and remove the formatter instead.
- No space before and only one space after colons
- Consistent capitalization

Signed-off-by: Bora M. Alper <bora@boramalper.org>