### PR TITLE
Quieter setup_node.sh

### DIFF
--- a/scripts/install_go.sh
+++ b/scripts/install_go.sh
@@ -24,7 +24,7 @@
 
 set -e
 
-wget https://golang.org/dl/go1.15.8.linux-amd64.tar.gz
+wget --continue --quiet https://golang.org/dl/go1.15.8.linux-amd64.tar.gz
 
 sudo tar -C /usr/local -xzf go1.15.8.linux-amd64.tar.gz
 

--- a/scripts/install_stock.sh
+++ b/scripts/install_stock.sh
@@ -26,13 +26,13 @@ sudo apt-get update >> /dev/null
 
 sudo apt-get -y install btrfs-tools pkg-config libseccomp-dev unzip tar libseccomp2 socat util-linux apt-transport-https curl ipvsadm >> /dev/null
 
-wget -c https://github.com/google/protobuf/releases/download/v3.11.4/protoc-3.11.4-linux-x86_64.zip
-sudo unzip protoc-3.11.4-linux-x86_64.zip -d /usr/local
+wget --continue --quiet https://github.com/google/protobuf/releases/download/v3.11.4/protoc-3.11.4-linux-x86_64.zip
+sudo unzip -q protoc-3.11.4-linux-x86_64.zip -d /usr/local
 
-wget https://github.com/containerd/containerd/releases/download/v1.4.1/containerd-1.4.1-linux-amd64.tar.gz
+wget --continue --quiet https://github.com/containerd/containerd/releases/download/v1.4.1/containerd-1.4.1-linux-amd64.tar.gz
 sudo tar -C /usr/local -xzf containerd-1.4.1-linux-amd64.tar.gz
 
-wget https://github.com/opencontainers/runc/releases/download/v1.0.0-rc92/runc.amd64
+wget --continue --quiet https://github.com/opencontainers/runc/releases/download/v1.0.0-rc92/runc.amd64
 mv runc.amd64 runc
 sudo install -D -m0755 runc /usr/local/sbin/runc
 
@@ -41,13 +41,13 @@ containerd --version || echo "failed to build containerd"
 
 # Install k8s
 K8S_VERSION=1.20.6-00
-curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
+curl --silent --show-error https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
 sudo sh -c "echo 'deb http://apt.kubernetes.io/ kubernetes-xenial main' > /etc/apt/sources.list.d/kubernetes.list"
-sudo apt update >> /dev/null
-sudo apt -y install cri-tools ebtables ethtool kubeadm=$K8S_VERSION kubectl=$K8S_VERSION kubelet=$K8S_VERSION kubernetes-cni
+sudo apt-get update >> /dev/null
+sudo apt-get -y install cri-tools ebtables ethtool kubeadm=$K8S_VERSION kubectl=$K8S_VERSION kubelet=$K8S_VERSION kubernetes-cni >> /dev/null
 
 # Install knative CLI
-git clone https://github.com/knative/client.git $HOME/client
+git clone --quiet --depth=1 https://github.com/knative/client.git $HOME/client
 cd $HOME/client
 hack/build.sh -f
 sudo mv kn /usr/local/bin
@@ -64,4 +64,4 @@ net.ipv4.ip_forward                 = 1
 net.bridge.bridge-nf-call-ip6tables = 1
 EOF
 
-sudo sysctl --system
+sudo sysctl --quiet --system

--- a/scripts/setup_system.sh
+++ b/scripts/setup_system.sh
@@ -24,8 +24,8 @@
 
 # Add skopeo sources
 . /etc/os-release
-echo "deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/ /" | sudo tee /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list
-curl -L https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/Release.key | sudo apt-key add -
+echo "deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/ /" | sudo tee /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list > /dev/null
+curl --silent --show-error -L https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/Release.key | sudo apt-key add -
 
 sudo apt-get update >> /dev/null
 
@@ -62,14 +62,14 @@ sudo sh -c "echo \"* hard stack 65536\" >> /etc/security/limits.conf"
 sudo sh -c "echo \"root soft stack 65536\" >> /etc/security/limits.conf"
 sudo sh -c "echo \"root hard stack 65536\" >> /etc/security/limits.conf"
 
-sudo sysctl -w net.ipv4.conf.all.forwarding=1
+sudo sysctl --quiet -w net.ipv4.conf.all.forwarding=1
 # Avoid "neighbour: arp_cache: neighbor table overflow!"
-sudo sysctl -w net.ipv4.neigh.default.gc_thresh1=1024
-sudo sysctl -w net.ipv4.neigh.default.gc_thresh2=2048
-sudo sysctl -w net.ipv4.neigh.default.gc_thresh3=4096
-sudo sysctl -w net.ipv4.ip_local_port_range="32769 65535"
-sudo sysctl -w kernel.pid_max=4194303
-sudo sysctl -w kernel.threads-max=999999999
+sudo sysctl --quiet -w net.ipv4.neigh.default.gc_thresh1=1024
+sudo sysctl --quiet -w net.ipv4.neigh.default.gc_thresh2=2048
+sudo sysctl --quiet -w net.ipv4.neigh.default.gc_thresh3=4096
+sudo sysctl --quiet -w net.ipv4.ip_local_port_range="32769 65535"
+sudo sysctl --quiet -w kernel.pid_max=4194303
+sudo sysctl --quiet -w kernel.threads-max=999999999
 sudo swapoff -a
-sudo sysctl net.ipv4.ip_forward=1
-sudo sysctl --system
+sudo sysctl --quiet net.ipv4.ip_forward=1
+sudo sysctl --quiet --system


### PR DESCRIPTION
Make `setup_node.sh` quieter and more compliant

- Use "quiet" flag on commands that do not need to be verbose
- Prefer commands intended for scripting usage (e.g., `apt-get` over `apt`)

Edit: Just realised that I built this upon my previous work on updating the quickstart guide so this PR includes that commit too. Sorry! Not sure how to isolate this and that, but let me know if I can help.
