### PR TITLE
Improve setup_nodes.sh

### DIFF
--- a/scripts/cloudlab/setup_node.sh
+++ b/scripts/cloudlab/setup_node.sh
@@ -28,6 +28,8 @@ SCRIPTS=$ROOT/scripts
 
 STOCK_CONTAINERD=$1
 
+$SCRIPTS/disable_auto_updates.sh
+
 source $SCRIPTS/install_go.sh
 $SCRIPTS/setup_system.sh
 

--- a/scripts/disable_auto_updates.sh
+++ b/scripts/disable_auto_updates.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+# MIT License
+#
+# Copyright (c) 2021 Mert Bora Alper and EASE lab
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+# There are no "clean" solutions sadly... Try your best!
+
+sudo rm -f /etc/apt/apt.conf.d/20auto-upgrades
+sudo tee /etc/apt/apt.conf.d/99auto-upgrades <<EOF
+APT::Periodic::Update-Package-Lists "0";
+APT::Periodic::Download-Upgradeable-Packages "0";
+APT::Periodic::AutocleanInterval "0";
+APT::Periodic::Unattended-Upgrade "0";
+EOF
+
+# Disable the systemd timers that schedule the apt updates/upgrades
+# Source: https://saveriomiroddi.github.io/Handling-the-apt-lock-on-ubuntu-server-installations/#comment-5277734269
+sudo systemctl stop apt-daily.timer apt-daily-upgrade.timer
+sudo systemctl mask apt-daily.service apt-daily-upgrade.service
+sudo systemctl kill --kill-who=all apt-daily.service
+sudo rm -f /var/lib/systemd/timers/stamp-apt-daily.timer
+sudo rm -f /var/lib/systemd/timers/stamp-apt-daily-upgrade.timer
+
+# wait until `apt-get updated` has been killed
+while ! (systemctl list-units --all apt-daily.service | egrep -q '(dead|failed)')
+do
+  sleep 1
+done
+
+# Source: https://askubuntu.com/a/375031/388226
+while fuser /var/lib/dpkg/lock >/dev/null 2>&1 ; do
+    sleep 1
+done 

--- a/scripts/install_stock.sh
+++ b/scripts/install_stock.sh
@@ -27,7 +27,7 @@ sudo apt-get update >> /dev/null
 sudo apt-get -y install btrfs-tools pkg-config libseccomp-dev unzip tar libseccomp2 socat util-linux apt-transport-https curl ipvsadm >> /dev/null
 
 wget --continue --quiet https://github.com/google/protobuf/releases/download/v3.11.4/protoc-3.11.4-linux-x86_64.zip
-sudo unzip -q protoc-3.11.4-linux-x86_64.zip -d /usr/local
+sudo unzip -o -q protoc-3.11.4-linux-x86_64.zip -d /usr/local
 
 wget --continue --quiet https://github.com/containerd/containerd/releases/download/v1.4.1/containerd-1.4.1-linux-amd64.tar.gz
 sudo tar -C /usr/local -xzf containerd-1.4.1-linux-amd64.tar.gz

--- a/scripts/setup_system.sh
+++ b/scripts/setup_system.sh
@@ -70,6 +70,6 @@ sudo sysctl --quiet -w net.ipv4.neigh.default.gc_thresh3=4096
 sudo sysctl --quiet -w net.ipv4.ip_local_port_range="32769 65535"
 sudo sysctl --quiet -w kernel.pid_max=4194303
 sudo sysctl --quiet -w kernel.threads-max=999999999
-sudo swapoff -a
+sudo swapoff -a >> /dev/null
 sudo sysctl --quiet net.ipv4.ip_forward=1
 sudo sysctl --quiet --system


### PR DESCRIPTION
- Silence `swapoff` errors
- Overwrite all without asking on unzipping `protoc`
- Try our best to kill/prevent conflicting apt processes running in background
  - You may find this an overkill, I can revert it if you like but this should address the `E: Sub-process /usr/bin/dpkg returned an error code (1)` family of errors that @MBaczun and I (too) have experienced.
