### PR TITLE
Pin Knative to v0.21.0

### DIFF
--- a/scripts/install_stock.sh
+++ b/scripts/install_stock.sh
@@ -47,7 +47,8 @@ sudo apt-get update >> /dev/null
 sudo apt-get -y install cri-tools ebtables ethtool kubeadm=$K8S_VERSION kubectl=$K8S_VERSION kubelet=$K8S_VERSION kubernetes-cni >> /dev/null
 
 # Install knative CLI
-git clone --quiet --depth=1 https://github.com/knative/client.git $HOME/client
+KNATIVE_VERSION=v0.21.0
+git clone --quiet --depth=1 --branch=$KNATIVE_VERSION -c advice.detachedHead=false https://github.com/knative/client.git $HOME/client
 cd $HOME/client
 hack/build.sh -f
 sudo mv kn /usr/local/bin


### PR DESCRIPTION
Tested:

```
$ kn version
Version:      v20210531-local-5f68d61
Build Date:   2021-05-31 09:53:40
Git Revision: 5f68d61
Supported APIs:
* Serving
  - serving.knative.dev/v1 (knative-serving v0.21.0)
* Eventing
  - sources.knative.dev/v1alpha2 (knative-eventing v0.21.0)
  - eventing.knative.dev/v1beta1 (knative-eventing v0.21.0)
```

`Version` field is sadly misleading; it is basically the build date... `Git Revision` (also the suffix of `Version`) is `5f68d61` and is equal to the [hash of v0.21.0](https://github.com/knative/client/releases/tag/v0.21.0). Rest is self-explanatory.