### PR TITLE
Pin pmu-tools to a specific version (commit)

### DIFF
--- a/scripts/install_pmutools.sh
+++ b/scripts/install_pmutools.sh
@@ -28,6 +28,8 @@ sudo apt-get install numactl \
     linux-tools-`uname -r`  -y
 
 sudo git clone https://github.com/andikleen/pmu-tools /usr/local/pmu-tools
+# Pin pmu-tools to a specific commit:
+sudo bash -c "cd /usr/local/pmu-tools; git reset --hard 6f54a01fe939e9e11b90272a173a0fdb76969e87"
 
 sudo sysctl -w kernel.perf_event_paranoid=-1
 


### PR DESCRIPTION
CI pipeline seems broken:
- https://github.com/ease-lab/vhive/pull/250
  - https://github.com/ease-lab/vhive/pull/250/checks?check_run_id=2727737979
  - https://github.com/ease-lab/vhive/pull/250/checks?check_run_id=2727738026
  - https://github.com/ease-lab/vhive/pull/250/checks?check_run_id=2727738068
- https://github.com/ease-lab/vhive/pull/251
  - https://github.com/ease-lab/vhive/pull/251/checks?check_run_id=2727582053
  - https://github.com/ease-lab/vhive/pull/251/checks?check_run_id=2727582087
  - https://github.com/ease-lab/vhive/pull/251/checks?check_run_id=2727582109

All of these fail the task "Install PMU tools".

I think the issue is stems at `install_pmutools.sh ` where we clone [`andikleen/pmu-tools`](https://github.com/andikleen/pmu-tools) without pinning its version. I believe that [its recent commits](https://github.com/andikleen/pmu-tools/commits/master) might have broken it.

I pinned it to commit [`6f54a01fe939e9e11b90272a173a0fdb76969e87`](https://github.com/andikleen/pmu-tools/commit/6f54a01fe939e9e11b90272a173a0fdb76969e87) from 5 days ago, which is also known to pass **both** our and their tests. Let's see the tests for this PR.

Signed-off-by: Bora M. Alper <bora@boramalper.org>