### PR TITLE
Created generic coordinator for cri

### DIFF
--- a/cri/Makefile
+++ b/cri/Makefile
@@ -38,7 +38,7 @@ test:
 	KUBECONFIG=/etc/kubernetes/admin.conf kn service apply pyaes -f ./../configs/knative_workloads/pyaes.yaml
 	sleep 1m
 
-	go test ./ $(EXTRAGOARGS)
+	go test ./... $(EXTRAGOARGS)
 
 test-man:
 	echo "Nothing to test manually"

--- a/cri/container_create.go
+++ b/cri/container_create.go
@@ -79,20 +79,20 @@ func (s *Service) createUserContainer(ctx context.Context, r *criapi.CreateConta
 		return nil, err
 	}
 
-	funcInst, err := s.coordinator.startVM(context.Background(), guestImage)
+	funcInst, err := s.coordinator.StartSandbox(context.Background(), guestImage)
 	if err != nil {
 		log.WithError(err).Error("failed to start VM")
 		return nil, err
 	}
 
-	vmConfig := &VMConfig{guestIP: funcInst.startVMResponse.GuestIP, guestPort: guestPortValue}
+	vmConfig := &VMConfig{guestIP: funcInst.StartVMResponse.GuestIP, guestPort: guestPortValue}
 	s.insertPodVMConfig(r.GetPodSandboxId(), vmConfig)
 
 	// Wait for placeholder UC to be created
 	<-stockDone
 
 	containerdID := stockResp.ContainerId
-	err = s.coordinator.insertActive(containerdID, funcInst)
+	err = s.coordinator.InsertActive(containerdID, funcInst)
 	if err != nil {
 		log.WithError(err).Error("failed to insert active VM")
 		return nil, err

--- a/cri/coordinator/firecracker/coordinator_test.go
+++ b/cri/coordinator/firecracker/coordinator_test.go
@@ -20,16 +20,28 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-package cri
+package firecracker
 
 import (
 	"context"
+	"os"
 	"strconv"
 	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
+
+var (
+	coord *FirecrackerCoordinator
+)
+
+func TestMain(m *testing.M) {
+	coord = NewFirecrackerCoordinator(nil, withoutOrchestrator())
+
+	ret := m.Run()
+	os.Exit(ret)
+}
 
 func TestStartStop(t *testing.T) {
 	containerID := "1"

--- a/cri/coordinator/funcInstance.go
+++ b/cri/coordinator/funcInstance.go
@@ -20,25 +20,37 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-package cri
+package coordinator
 
 import (
-	"context"
+	"sync"
 
+	"github.com/ease-lab/vhive/ctriface"
 	log "github.com/sirupsen/logrus"
-	criapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 )
 
-// RemoveContainer removes a container or a VM
-func (s *Service) RemoveContainer(ctx context.Context, r *criapi.RemoveContainerRequest) (*criapi.RemoveContainerResponse, error) {
-	log.Debugf("RemoveContainer for %q", r.GetContainerId())
-	containerID := r.GetContainerId()
+type FuncInstance struct {
+	VmID                   string
+	Image                  string
+	Logger                 *log.Entry
+	OnceCreateSnapInstance *sync.Once
+	StartVMResponse        *ctriface.StartVMResponse
+}
 
-	go func() {
-		if err := s.coordinator.StopSandbox(context.Background(), containerID); err != nil {
-			log.WithError(err).Error("failed to stop microVM")
-		}
-	}()
+func NewFuncInstance(vmID, image string, startVMResponse *ctriface.StartVMResponse) *FuncInstance {
+	f := &FuncInstance{
+		VmID:                   vmID,
+		Image:                  image,
+		OnceCreateSnapInstance: new(sync.Once),
+		StartVMResponse:        startVMResponse,
+	}
 
-	return s.stockRuntimeClient.RemoveContainer(ctx, r)
+	f.Logger = log.WithFields(
+		log.Fields{
+			"vmID":  vmID,
+			"image": image,
+		},
+	)
+
+	return f
 }

--- a/cri/coordinator/types.go
+++ b/cri/coordinator/types.go
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2020 Plamen Petrov and EASE lab
+// Copyright (c) 2020 Nathaniel Tornow and EASE lab
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -20,37 +20,16 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-package cri
+package coordinator
 
 import (
-	"sync"
-
-	"github.com/ease-lab/vhive/ctriface"
-	log "github.com/sirupsen/logrus"
+	"context"
 )
 
-type funcInstance struct {
-	vmID                   string
-	image                  string
-	logger                 *log.Entry
-	onceCreateSnapInstance *sync.Once
-	startVMResponse        *ctriface.StartVMResponse
-}
-
-func newFuncInstance(vmID, image string, startVMResponse *ctriface.StartVMResponse) *funcInstance {
-	f := &funcInstance{
-		vmID:                   vmID,
-		image:                  image,
-		onceCreateSnapInstance: new(sync.Once),
-		startVMResponse:        startVMResponse,
-	}
-
-	f.logger = log.WithFields(
-		log.Fields{
-			"vmID":  vmID,
-			"image": image,
-		},
-	)
-
-	return f
+type Coordinator interface {
+	StartSandbox(context.Context, string) (*FuncInstance, error)
+	StopSandbox(context.Context, string) error
+	InsertActive(string, *FuncInstance) error
+	RemoveActive(string)
+	IsActive(string) bool
 }

--- a/cri/cri_test.go
+++ b/cri/cri_test.go
@@ -40,16 +40,12 @@ import (
 )
 
 var (
-	coord         *coordinator
 	gatewayURL    = flag.String("gatewayURL", "192.168.1.240.sslip.io", "URL of the gateway")
 	namespaceName = flag.String("namespace", "default", "name of namespace in which services exists")
 )
 
 func TestMain(m *testing.M) {
-	coord = newCoordinator(nil, withoutOrchestrator())
-
 	flag.Parse()
-
 	ret := m.Run()
 	os.Exit(ret)
 }

--- a/vhive.go
+++ b/vhive.go
@@ -33,6 +33,7 @@ import (
 
 	ctrdlog "github.com/containerd/containerd/log"
 	fccdcri "github.com/ease-lab/vhive/cri"
+	fccoor "github.com/ease-lab/vhive/cri/coordinator/firecracker"
 	ctriface "github.com/ease-lab/vhive/ctriface"
 	hpb "github.com/ease-lab/vhive/examples/protobuf/helloworld"
 	pb "github.com/ease-lab/vhive/proto"
@@ -152,7 +153,9 @@ func criServe() {
 
 	s := grpc.NewServer()
 
-	criService, err := fccdcri.NewService(orch)
+	coor := fccoor.NewFirecrackerCoordinator(orch)
+
+	criService, err := fccdcri.NewService(coor)
 	if err != nil {
 		log.Fatalf("failed to create CRI service %v", err)
 	}


### PR DESCRIPTION
Relates to #303 

- Created an interface "Coordinator" (in cri/coordinator/types.go), that coordinators need to implement in order to integrate with the vhive-cri. 
- Renamed and restructured firecracker-coordinator, which implements the coordinator-interface
- Changed service, so it works on the coordinator interface (takes a specific coordinator-type when creating)
- Commented out some lines on cri/container_create.go, which I think don't have an effect (besides maybe for testing). If there needed, we would have to add the function "InsertActive" to the Coordinator interface.

All tests (with `make test-cri`) are successful.