### PR TITLE
wrap stdio of workload containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Changed
 
+- Workload stdout/stderr is not directly redirected to vhive stdout/stderr anymore but is printed by vhive via `logrus.WithFields(logrus.Fields{"vmID": vmID})`.
 
 ### Fixed
 

--- a/configs/.wordlist.txt
+++ b/configs/.wordlist.txt
@@ -493,6 +493,7 @@ virtualized
 Vlachos
 VLDB
 vm
+vmID
 VM
 vmIncrStep
 VMs
@@ -502,6 +503,7 @@ WDDD
 wget
 WIDX
 WIOSCA
+WithFields
 WithInsecure
 WithUnaryInterceptor
 WoNDP


### PR DESCRIPTION
Instead of redirecting workload container stderr and stdout to vhive stderr and stdout, it is now logged as:
```
time="2021-07-02T16:52:41.467607817Z" level=info msg="ERROR:root:testing logging2" vmID=15
```

Tested with [pyaes code](https://github.com/pogobanane/vhive/commit/cc27d35d4c125e197af9060a77a928e63c3bb0e6) / [image@docker hub](https://hub.docker.com/layers/154495195/pogobanane/vhive-workloads/slow_pyaes/images/sha256-cb84fe3df946c06be5b70c3b91475a27e07ea4389cc5931c6247ef1f8cf33578?context=explore). 