### PR TITLE
Added Error checking for container creation

### DIFF
--- a/cri/container_create.go
+++ b/cri/container_create.go
@@ -91,6 +91,12 @@ func (s *Service) createUserContainer(ctx context.Context, r *criapi.CreateConta
 	// Wait for placeholder UC to be created
 	<-stockDone
 
+	// Check for error from container creation
+	if stockErr != nil {
+		log.WithError(stockErr).Error("failed to create container")
+		return nil, stockErr
+	}
+	
 	containerdID := stockResp.ContainerId
 	err = s.coordinator.insertActive(containerdID, funcInst)
 	if err != nil {


### PR DESCRIPTION
Insert error checking for container creation after calling stockRuntimeClient.CreateContainer
Not checking for this error lead to access on null pointer if the container creation failed.
Should fix #219