### PR TITLE
Video bench min scale

### DIFF
--- a/.github/workflows/function-composition.yml
+++ b/.github/workflows/function-composition.yml
@@ -171,6 +171,7 @@ jobs:
           ./bin/grpcurl -max-time 10 -plaintext localhost:3031 helloworld.Greeter.SayHello
 
       - name: show docker-compose log
+        if: ${{ always() }}
         run: cat function-images/tests/chained-function-serving/log_file
 
   bench-serving:
@@ -327,14 +328,25 @@ jobs:
         run: |
           ./function-images/tests/kn_deploy.sh ./function-images/tests/video-analytics/knative_yamls/${{ matrix.transfer-type }}/service*
 
+      - uses: actions/setup-go@v2
+        with:
+          go-version: 1.16
+
+      - name: Build invoker
+        working-directory: examples/invoker
+        run: make invoker
+
       - name: Invoke functions
+        working-directory: examples/invoker
         run: |
           set -x
 
           NODEPORT=$(kubectl get svc kourier-ingress -n kourier-system -o=jsonpath='{.spec.ports[0].nodePort}')
           HOSTNAME=$(kubectl get ksvc streaming -n default -o jsonpath='{.status.url}' | cut -c8-)
 
-          ./bin/grpcurl -plaintext $HOSTNAME:$NODEPORT helloworld.Greeter.SayHello
+          echo '[ { "hostname": "$HOSTNAME" } ]' > endpoints.json
+          ./invoker -port $NODEPORT -dbg
+          cat rps*lat.csv
 
       - name: Print logs
         if: ${{ always() }}

--- a/function-images/tests/video-analytics/Dockerfile
+++ b/function-images/tests/video-analytics/Dockerfile
@@ -33,8 +33,6 @@ COPY ./function-images/tests/video-analytics/proto/videoservice_pb2_grpc.py ./
 COPY ./function-images/tests/video-analytics/proto/videoservice_pb2.py ./
 RUN --mount=type=secret,id=GOPRIVATE_KEY \
         git config --global url."https://ease-lab:$(cat /run/secrets/GOPRIVATE_KEY)@github.com/ease-lab/vhive-xdt".insteadOf "https://github.com/ease-lab/vhive-xdt"
-RUN --mount=type=secret,id=GOPRIVATE_KEY \
-    curl https://$(cat /run/secrets/GOPRIVATE_KEY):x-oauth-basic@api.github.com/repos/ease-lab/vhive-xdt/git/refs/heads/python-sdk-use-metadata-at-dst -o version.json
 RUN git clone --depth 1 https://github.com/ease-lab/vhive-xdt /xdt
 
 FROM vhiveease/python-slim:latest as recog
@@ -62,8 +60,6 @@ COPY ./function-images/tests/video-analytics/proto/videoservice_pb2_grpc.py ./
 COPY ./function-images/tests/video-analytics/proto/videoservice_pb2.py ./
 RUN --mount=type=secret,id=GOPRIVATE_KEY \
         git config --global url."https://ease-lab:$(cat /run/secrets/GOPRIVATE_KEY)@github.com/ease-lab/vhive-xdt".insteadOf "https://github.com/ease-lab/vhive-xdt"
-RUN --mount=type=secret,id=GOPRIVATE_KEY \
-    curl https://$(cat /run/secrets/GOPRIVATE_KEY):x-oauth-basic@api.github.com/repos/ease-lab/vhive-xdt/git/refs/heads/python-sdk-use-metadata-at-dst -o version.json
 RUN git clone --depth 1 https://github.com/ease-lab/vhive-xdt /xdt
 
 FROM vhiveease/python-slim:latest as decode

--- a/function-images/tests/video-analytics/docker-compose-inline.yml
+++ b/function-images/tests/video-analytics/docker-compose-inline.yml
@@ -40,6 +40,7 @@ services:
             - -zipkin=http://zipkin:9411/api/v2/spans
         environment:
             - MAX_DECODER_SERVER_THREADS=10
+            - CONCURRENT_RECOG=false
         depends_on: 
             - recog
 

--- a/function-images/tests/video-analytics/docker-compose-s3-tracing.yml
+++ b/function-images/tests/video-analytics/docker-compose-s3-tracing.yml
@@ -34,7 +34,7 @@ services:
             - -sp=50053
             - -zipkin=http://zipkin:9411/api/v2/spans
         environment:
-            - USES3=true
+            - TRANSFER_TYPE=S3
             - AWS_ACCESS_KEY=${AWS_ACCESS_KEY}
             - AWS_SECRET_KEY=${AWS_SECRET_KEY}
             - AWS_REGION=us-west-1
@@ -57,6 +57,7 @@ services:
             - AWS_REGION=us-west-1
             - ENABLE_TRACING=true
             - MAX_DECODER_SERVER_THREADS=10
+            - CONCURRENT_RECOG=false
         depends_on:
             - recog
 

--- a/function-images/tests/video-analytics/docker-compose-s3.yml
+++ b/function-images/tests/video-analytics/docker-compose-s3.yml
@@ -48,6 +48,7 @@ services:
             - AWS_SECRET_KEY=${AWS_SECRET_KEY}
             - AWS_REGION=us-west-1
             - MAX_DECODER_SERVER_THREADS=10
+            - CONCURRENT_RECOG=false
         depends_on: 
             - recog
 

--- a/function-images/tests/video-analytics/docker-compose-tracing.yml
+++ b/function-images/tests/video-analytics/docker-compose-tracing.yml
@@ -49,6 +49,7 @@ services:
         environment:
             - ENABLE_TRACING=true
             - MAX_DECODER_SERVER_THREADS=10
+            - CONCURRENT_RECOG=false
         depends_on:
             - recog
 

--- a/function-images/tests/video-analytics/docker-compose-xdt.yml
+++ b/function-images/tests/video-analytics/docker-compose-xdt.yml
@@ -45,13 +45,14 @@ services:
             - -zipkin=http://zipkin:9411/api/v2/spans
         environment:
             - TRANSFER_TYPE=XDT
+            - CONCURRENT_RECOG=false
             - SQP_SERVER_HOSTNAME=decoder-sQP
             - SQP_SERVER_PORT=:50005
             - DQP_SERVER_HOSTNAME=decoder-dQP
             - DQP_SERVER_PORT=:50006
             - DST_SERVER_HOSTNAME=decoder
             - DST_SERVER_PORT=:50052
-        depends_on: 
+        depends_on:
             - recog
             - decoder-dQP
             - decoder-sQP

--- a/function-images/tests/video-analytics/knative_yamls/inline/service-decoder.yaml
+++ b/function-images/tests/video-analytics/knative_yamls/inline/service-decoder.yaml
@@ -27,6 +27,10 @@ metadata:
   namespace: default
 spec:
   template:
+    metadata:
+      annotations:
+        # prevent cold boots
+        autoscaling.knative.dev/minScale: "1"
     spec:
       containers:
         - image: docker.io/vhiveease/video-analytics-decoder:latest

--- a/function-images/tests/video-analytics/knative_yamls/inline/service-decoder.yaml
+++ b/function-images/tests/video-analytics/knative_yamls/inline/service-decoder.yaml
@@ -31,7 +31,9 @@ spec:
       annotations:
         # prevent cold boots
         autoscaling.knative.dev/minScale: "1"
+        autoscaling.knative.dev/maxScale: "1"
     spec:
+      containerConcurrency: 1
       containers:
         - image: docker.io/vhiveease/video-analytics-decoder:latest
           imagePullPolicy: Always

--- a/function-images/tests/video-analytics/knative_yamls/inline/service-decoder.yaml
+++ b/function-images/tests/video-analytics/knative_yamls/inline/service-decoder.yaml
@@ -36,6 +36,8 @@ spec:
               value: "INLINE"
             - name: DecoderFrames
               value: "3"
+            - name: CONCURRENT_RECOG
+              value: "false"
             - name: MAX_DECODER_SERVER_THREADS
               value: "10"
             - name: ENABLE_TRACING

--- a/function-images/tests/video-analytics/knative_yamls/inline/service-decoder.yaml
+++ b/function-images/tests/video-analytics/knative_yamls/inline/service-decoder.yaml
@@ -39,13 +39,13 @@ spec:
             - name: TRANSFER_TYPE
               value: "INLINE"
             - name: DecoderFrames
-              value: "3"
+              value: "6"
             - name: CONCURRENT_RECOG
               value: "false"
             - name: MAX_DECODER_SERVER_THREADS
               value: "10"
             - name: ENABLE_TRACING
-              value: "false"
+              value: "true"
           ports:
             # For `h2c`, see https://knative.tips/networking/http2/
             - name: h2c

--- a/function-images/tests/video-analytics/knative_yamls/inline/service-recog.yaml
+++ b/function-images/tests/video-analytics/knative_yamls/inline/service-recog.yaml
@@ -31,7 +31,9 @@ spec:
       annotations:
         # set this equal to DecoderFrames in decoder manifest
         autoscaling.knative.dev/minScale: "6"
+        autoscaling.knative.dev/maxScale: "6"
     spec:
+      containerConcurrency: 1
       containers:
         - image: docker.io/vhiveease/video-analytics-recog:latest
           imagePullPolicy: Always

--- a/function-images/tests/video-analytics/knative_yamls/inline/service-recog.yaml
+++ b/function-images/tests/video-analytics/knative_yamls/inline/service-recog.yaml
@@ -30,7 +30,7 @@ spec:
     metadata:
       annotations:
         # set this equal to DecoderFrames in decoder manifest
-        autoscaling.knative.dev/minScale: "3"
+        autoscaling.knative.dev/minScale: "6"
     spec:
       containers:
         - image: docker.io/vhiveease/video-analytics-recog:latest
@@ -41,7 +41,7 @@ spec:
             - name: MAX_RECOG_SERVER_THREADS
               value: "10"
             - name: ENABLE_TRACING
-              value: "false"
+              value: "true"
           ports:
             # For `h2c`, see https://knative.tips/networking/http2/
             - name: h2c

--- a/function-images/tests/video-analytics/knative_yamls/inline/service-recog.yaml
+++ b/function-images/tests/video-analytics/knative_yamls/inline/service-recog.yaml
@@ -27,6 +27,10 @@ metadata:
   namespace: default
 spec:
   template:
+    metadata:
+      annotations:
+        # set this equal to DecoderFrames in decoder manifest
+        autoscaling.knative.dev/minScale: "3"
     spec:
       containers:
         - image: docker.io/vhiveease/video-analytics-recog:latest

--- a/function-images/tests/video-analytics/knative_yamls/inline/service-streaming.yaml
+++ b/function-images/tests/video-analytics/knative_yamls/inline/service-streaming.yaml
@@ -31,7 +31,9 @@ spec:
       annotations:
         # prevent cold boots
         autoscaling.knative.dev/minScale: "1"
+        autoscaling.knative.dev/maxScale: "1"
     spec:
+      containerConcurrency: 1
       containers:
         - image: docker.io/vhiveease/video-analytics-streaming:latest
           imagePullPolicy: Always

--- a/function-images/tests/video-analytics/knative_yamls/inline/service-streaming.yaml
+++ b/function-images/tests/video-analytics/knative_yamls/inline/service-streaming.yaml
@@ -27,6 +27,10 @@ metadata:
   namespace: default
 spec:
   template:
+    metadata:
+      annotations:
+        # prevent cold boots
+        autoscaling.knative.dev/minScale: "1"
     spec:
       containers:
         - image: docker.io/vhiveease/video-analytics-streaming:latest

--- a/function-images/tests/video-analytics/knative_yamls/inline/service-streaming.yaml
+++ b/function-images/tests/video-analytics/knative_yamls/inline/service-streaming.yaml
@@ -39,7 +39,7 @@ spec:
             - name: TRANSFER_TYPE
               value: "INLINE"
             - name: ENABLE_TRACING
-              value: "false"
+              value: "true"
           ports:
             # For `h2c`, see https://knative.tips/networking/http2/
             - name: h2c

--- a/function-images/tests/video-analytics/knative_yamls/s3/service-decoder.yaml
+++ b/function-images/tests/video-analytics/knative_yamls/s3/service-decoder.yaml
@@ -45,13 +45,13 @@ spec:
             - name: AWS_REGION
               value: "us-west-1"
             - name: DecoderFrames
-              value: "3"
+              value: "6"
             - name: CONCURRENT_RECOG
               value: "false"
             - name: MAX_DECODER_SERVER_THREADS
               value: "10"
             - name: ENABLE_TRACING
-              value: "false"
+              value: "true"
           ports:
             # For `h2c`, see https://knative.tips/networking/http2/
             - name: h2c

--- a/function-images/tests/video-analytics/knative_yamls/s3/service-decoder.yaml
+++ b/function-images/tests/video-analytics/knative_yamls/s3/service-decoder.yaml
@@ -27,6 +27,10 @@ metadata:
   namespace: default
 spec:
   template:
+    metadata:
+      annotations:
+        # prevent cold boots
+        autoscaling.knative.dev/minScale: "1"
     spec:
       containers:
         - image: docker.io/vhiveease/video-analytics-decoder:latest

--- a/function-images/tests/video-analytics/knative_yamls/s3/service-decoder.yaml
+++ b/function-images/tests/video-analytics/knative_yamls/s3/service-decoder.yaml
@@ -31,7 +31,9 @@ spec:
       annotations:
         # prevent cold boots
         autoscaling.knative.dev/minScale: "1"
+        autoscaling.knative.dev/maxScale: "1"
     spec:
+      containerConcurrency: 1
       containers:
         - image: docker.io/vhiveease/video-analytics-decoder:latest
           imagePullPolicy: Always

--- a/function-images/tests/video-analytics/knative_yamls/s3/service-decoder.yaml
+++ b/function-images/tests/video-analytics/knative_yamls/s3/service-decoder.yaml
@@ -42,6 +42,8 @@ spec:
               value: "us-west-1"
             - name: DecoderFrames
               value: "3"
+            - name: CONCURRENT_RECOG
+              value: "false"
             - name: MAX_DECODER_SERVER_THREADS
               value: "10"
             - name: ENABLE_TRACING

--- a/function-images/tests/video-analytics/knative_yamls/s3/service-recog.yaml
+++ b/function-images/tests/video-analytics/knative_yamls/s3/service-recog.yaml
@@ -31,7 +31,9 @@ spec:
       annotations:
         # set this equal to DecoderFrames in decoder manifest
         autoscaling.knative.dev/minScale: "6"
+        autoscaling.knative.dev/maxScale: "6"
     spec:
+      containerConcurrency: 1
       containers:
         - image: docker.io/vhiveease/video-analytics-recog:latest
           imagePullPolicy: Always

--- a/function-images/tests/video-analytics/knative_yamls/s3/service-recog.yaml
+++ b/function-images/tests/video-analytics/knative_yamls/s3/service-recog.yaml
@@ -30,7 +30,7 @@ spec:
     metadata:
       annotations:
         # set this equal to DecoderFrames in decoder manifest
-        autoscaling.knative.dev/minScale: "3"
+        autoscaling.knative.dev/minScale: "6"
     spec:
       containers:
         - image: docker.io/vhiveease/video-analytics-recog:latest
@@ -47,7 +47,7 @@ spec:
             - name: MAX_RECOG_SERVER_THREADS
               value: "10"
             - name: ENABLE_TRACING
-              value: "false"
+              value: "true"
           ports:
             # For `h2c`, see https://knative.tips/networking/http2/
             - name: h2c

--- a/function-images/tests/video-analytics/knative_yamls/s3/service-recog.yaml
+++ b/function-images/tests/video-analytics/knative_yamls/s3/service-recog.yaml
@@ -27,6 +27,10 @@ metadata:
   namespace: default
 spec:
   template:
+    metadata:
+      annotations:
+        # set this equal to DecoderFrames in decoder manifest
+        autoscaling.knative.dev/minScale: "3"
     spec:
       containers:
         - image: docker.io/vhiveease/video-analytics-recog:latest

--- a/function-images/tests/video-analytics/knative_yamls/s3/service-streaming.yaml
+++ b/function-images/tests/video-analytics/knative_yamls/s3/service-streaming.yaml
@@ -31,7 +31,9 @@ spec:
       annotations:
         # prevent cold boots
         autoscaling.knative.dev/minScale: "1"
+        autoscaling.knative.dev/maxScale: "1"
     spec:
+      containerConcurrency: 1
       containers:
         - image: docker.io/vhiveease/video-analytics-streaming:latest
           imagePullPolicy: Always

--- a/function-images/tests/video-analytics/knative_yamls/s3/service-streaming.yaml
+++ b/function-images/tests/video-analytics/knative_yamls/s3/service-streaming.yaml
@@ -45,7 +45,7 @@ spec:
             - name: AWS_REGION
               value: "us-west-1"
             - name: ENABLE_TRACING
-              value: "false"
+              value: "true"
           ports:
             # For `h2c`, see https://knative.tips/networking/http2/
             - name: h2c

--- a/function-images/tests/video-analytics/knative_yamls/s3/service-streaming.yaml
+++ b/function-images/tests/video-analytics/knative_yamls/s3/service-streaming.yaml
@@ -27,6 +27,10 @@ metadata:
   namespace: default
 spec:
   template:
+    metadata:
+      annotations:
+        # prevent cold boots
+        autoscaling.knative.dev/minScale: "1"
     spec:
       containers:
         - image: docker.io/vhiveease/video-analytics-streaming:latest

--- a/function-images/tests/video-analytics/knative_yamls/xdt/service-decoder.yaml
+++ b/function-images/tests/video-analytics/knative_yamls/xdt/service-decoder.yaml
@@ -27,6 +27,10 @@ metadata:
   namespace: default
 spec:
   template:
+    metadata:
+      annotations:
+        # prevent cold boots
+        autoscaling.knative.dev/minScale: "1"
     spec:
       containers:
         - image: docker.io/vhiveease/video-analytics-decoder:latest

--- a/function-images/tests/video-analytics/knative_yamls/xdt/service-decoder.yaml
+++ b/function-images/tests/video-analytics/knative_yamls/xdt/service-decoder.yaml
@@ -36,6 +36,8 @@ spec:
               value: "XDT"
             - name: DecoderFrames
               value: "3"
+            - name: CONCURRENT_RECOG
+              value: "false"
             - name: MAX_DECODER_SERVER_THREADS
               value: "10"
             - name: ENABLE_TRACING

--- a/function-images/tests/video-analytics/knative_yamls/xdt/service-decoder.yaml
+++ b/function-images/tests/video-analytics/knative_yamls/xdt/service-decoder.yaml
@@ -31,7 +31,9 @@ spec:
       annotations:
         # prevent cold boots
         autoscaling.knative.dev/minScale: "1"
+        autoscaling.knative.dev/maxScale: "1"
     spec:
+      containerConcurrency: 1
       containers:
         - image: docker.io/vhiveease/video-analytics-decoder:latest
           imagePullPolicy: Always

--- a/function-images/tests/video-analytics/knative_yamls/xdt/service-decoder.yaml
+++ b/function-images/tests/video-analytics/knative_yamls/xdt/service-decoder.yaml
@@ -39,13 +39,13 @@ spec:
             - name: TRANSFER_TYPE
               value: "XDT"
             - name: DecoderFrames
-              value: "3"
+              value: "6"
             - name: CONCURRENT_RECOG
               value: "false"
             - name: MAX_DECODER_SERVER_THREADS
               value: "10"
             - name: ENABLE_TRACING
-              value: "false"
+              value: "true"
             - name: CHUNK_SIZE_IN_BYTES
               value: "65536"
             - name: CT_BUFFER_SIZE
@@ -57,7 +57,7 @@ spec:
             - name: ROUTING
               value: "CutThrough"
             - name: TRACING_ENABLED
-              value: "false"
+              value: "true"
             - name: RPC_TIMEOUT_MAX_BACK_OFF
               value: "1000"
             - name: RPC_TIMEOUT_DURATION

--- a/function-images/tests/video-analytics/knative_yamls/xdt/service-recog.yaml
+++ b/function-images/tests/video-analytics/knative_yamls/xdt/service-recog.yaml
@@ -30,7 +30,7 @@ spec:
     metadata:
       annotations:
         # set this equal to DecoderFrames in decoder manifest
-        autoscaling.knative.dev/minScale: "3"
+        autoscaling.knative.dev/minScale: "6"
     spec:
       containers:
         - image: docker.io/vhiveease/video-analytics-recog:latest
@@ -41,7 +41,7 @@ spec:
             - name: MAX_RECOG_SERVER_THREADS
               value: "10"
             - name: ENABLE_TRACING
-              value: "false"
+              value: "true"
             - name: CHUNK_SIZE_IN_BYTES
               value: "65536"
             - name: CT_BUFFER_SIZE
@@ -53,7 +53,7 @@ spec:
             - name: ROUTING
               value: "CutThrough"
             - name: TRACING_ENABLED
-              value: "false"
+              value: "true"
             - name: RPC_TIMEOUT_MAX_BACK_OFF
               value: "1000"
             - name: RPC_TIMEOUT_DURATION

--- a/function-images/tests/video-analytics/knative_yamls/xdt/service-recog.yaml
+++ b/function-images/tests/video-analytics/knative_yamls/xdt/service-recog.yaml
@@ -31,7 +31,9 @@ spec:
       annotations:
         # set this equal to DecoderFrames in decoder manifest
         autoscaling.knative.dev/minScale: "6"
+        autoscaling.knative.dev/maxScale: "6"
     spec:
+      containerConcurrency: 1
       containers:
         - image: docker.io/vhiveease/video-analytics-recog:latest
           imagePullPolicy: Always

--- a/function-images/tests/video-analytics/knative_yamls/xdt/service-recog.yaml
+++ b/function-images/tests/video-analytics/knative_yamls/xdt/service-recog.yaml
@@ -27,6 +27,10 @@ metadata:
   namespace: default
 spec:
   template:
+    metadata:
+      annotations:
+        # set this equal to DecoderFrames in decoder manifest
+        autoscaling.knative.dev/minScale: "3"
     spec:
       containers:
         - image: docker.io/vhiveease/video-analytics-recog:latest

--- a/function-images/tests/video-analytics/knative_yamls/xdt/service-streaming.yaml
+++ b/function-images/tests/video-analytics/knative_yamls/xdt/service-streaming.yaml
@@ -31,7 +31,9 @@ spec:
       annotations:
         # prevent cold boots
         autoscaling.knative.dev/minScale: "1"
+        autoscaling.knative.dev/maxScale: "1"
     spec:
+      containerConcurrency: 1
       containers:
         - image: docker.io/vhiveease/video-analytics-streaming:latest
           imagePullPolicy: Always

--- a/function-images/tests/video-analytics/knative_yamls/xdt/service-streaming.yaml
+++ b/function-images/tests/video-analytics/knative_yamls/xdt/service-streaming.yaml
@@ -49,7 +49,7 @@ spec:
             - name: ROUTING
               value: "CutThrough"
             - name: TRACING_ENABLED
-              value: "false"
+              value: "true"
             - name: RPC_TIMEOUT_MAX_BACK_OFF
               value: "1000"
             - name: RPC_TIMEOUT_DURATION
@@ -59,7 +59,7 @@ spec:
             - name: ZIPKIN_ENDPOINT
               value: "http://zipkin.istio-system.svc.cluster.local:9411/api/v2/spans"
             - name: ENABLE_TRACING
-              value: "false"
+              value: "true"
           ports:
             # For `h2c`, see https://knative.tips/networking/http2/
             - name: h2c

--- a/function-images/tests/video-analytics/knative_yamls/xdt/service-streaming.yaml
+++ b/function-images/tests/video-analytics/knative_yamls/xdt/service-streaming.yaml
@@ -27,6 +27,10 @@ metadata:
   namespace: default
 spec:
   template:
+    metadata:
+      annotations:
+        # prevent cold boots
+        autoscaling.knative.dev/minScale: "1"
     spec:
       containers:
         - image: docker.io/vhiveease/video-analytics-streaming:latest

--- a/function-images/tests/video-analytics/video_streaming/reference/video.mp4
+++ b/function-images/tests/video-analytics/video_streaming/reference/video.mp4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:62c74588d1321ae2bd273fde4a04da8d789ff2b60e2603caaa6725b7da82c718
-size 1174197
+oid sha256:e6167d243ad71f159752d0e120f81bdd8f56e1e99edd198dc3b432bedc4371ab
+size 1309217


### PR DESCRIPTION
- add minimum scale to manifests to prevent scaling to 0.
- add optional env variable `CONCURRENT_RECOG` to infer frames in parallel
  - #361
- add 1080p video sample video