### PR TITLE
Fixed invoker & deployer in the quickstart guide

### DIFF
--- a/docs/quickstart_guide.md
+++ b/docs/quickstart_guide.md
@@ -241,7 +241,7 @@ This section is only for synchronous (i.e., Knative Serving) functions. Please r
 1. Optionally, configure the types and the number of functions to deploy in `examples/deployer/functions.json`.
 2. Run the deployer client:
     ```bash
-    source /etc/profile && go run examples/deployer/client.go
+    source /etc/profile && pushd ./examples/deployer && go build && popd && ./examples/deployer/deployer
     ```
     > **BEWARE:**
     >
@@ -258,7 +258,7 @@ This section is only for synchronous (i.e., Knative Serving) functions. Please r
 
 1. Run the invoker client:
     ```bash
-    go run examples/invoker/client.go
+    pushd ./examples/invoker && go build && popd && ./examples/invoker/invoker
     ```
 
     > **Note:**

--- a/docs/quickstart_guide.md
+++ b/docs/quickstart_guide.md
@@ -263,6 +263,8 @@ This section is only for synchronous (i.e., Knative Serving) functions. Please r
 
     > **Note:**
     >
+    > In order to run the invoker client on another node, copy the `endpoints.json` file to the target node and run the invoker, specifying the path to the file as `-endpointsFile path/to/endpoints.json`.
+    >
     > There are runtime arguments (e.g., RPS or requests-per-second target, experiment duration) that you can specify if necessary.
     >
     > After invoking the functions from the input file (`endpoints.json` by default), the script writes the measured latencies to an output file (`rps<RPS>_lat.csv` by default, where `<RPS>` is the observed requests-per-sec value) for further analysis.


### PR DESCRIPTION
The invoker and the deployer tools need to be built from their enclosing folders. This bug was introduced by our go.mod files optimizations. 

Signed-off-by: Dmitrii Ustiugov <dmitrii.ustiugov@ed.ac.uk>