### PR TITLE
Unlock memory manager upon returning error

### DIFF
--- a/docs/knative/eventing.md
+++ b/docs/knative/eventing.md
@@ -21,7 +21,7 @@ A diagram of our design looks as follows, ignoring the extra interactions such a
 ![The diagram of our design.](./assets/broker.png)
 
 ### CloudEvents
-The core concepts of CloudEvents are [summarized](https://github.com/cloudevents/spec/blob/master/primer.md#cloudevents-concepts) in the following paragraph:
+The core concepts of CloudEvents are [summarized](https://github.com/cloudevents/spec/blob/v1.0.1/primer.md#cloudevents-concepts) in the following paragraph:
 
 > An **event** includes context and data about an **occurrence**. Each occurrence is uniquely identified by the data of the event.
 >

--- a/memory/manager/manager.go
+++ b/memory/manager/manager.go
@@ -131,6 +131,7 @@ func (m *MemoryManager) Activate(vmID string) error {
 
 	state, ok = m.instances[vmID]
 	if !ok {
+		m.Unlock()
 		logger.Error("VM not registered with the memory manager")
 		return errors.New("VM not registered with the memory manager")
 	}
@@ -178,6 +179,7 @@ func (m *MemoryManager) FetchState(vmID string) error {
 
 	state, ok = m.instances[vmID]
 	if !ok {
+		m.Unlock()
 		logger.Error("VM not registered with the memory manager")
 		return errors.New("VM not registered with the memory manager")
 	}
@@ -212,6 +214,7 @@ func (m *MemoryManager) Deactivate(vmID string) error {
 
 	state, ok = m.instances[vmID]
 	if !ok {
+		m.Unlock()
 		logger.Error("VM not registered with the memory manager")
 		return errors.New("VM not registered with the memory manager")
 	}
@@ -261,6 +264,7 @@ func (m *MemoryManager) DumpUPFPageStats(vmID, functionName, metricsOutFilePath 
 
 	state, ok := m.instances[vmID]
 	if !ok {
+		m.Unlock()
 		logger.Error("VM not registered with the memory manager")
 		return errors.New("VM not registered with the memory manager")
 	}
@@ -296,6 +300,7 @@ func (m *MemoryManager) DumpUPFLatencyStats(vmID, functionName, latencyOutFilePa
 
 	state, ok := m.instances[vmID]
 	if !ok {
+		m.Unlock()
 		logger.Error("VM not registered with the memory manager")
 		return errors.New("VM not registered with the memory manager")
 	}
@@ -326,6 +331,7 @@ func (m *MemoryManager) GetUPFLatencyStats(vmID string) ([]*metrics.Metric, erro
 
 	state, ok := m.instances[vmID]
 	if !ok {
+		m.Unlock()
 		logger.Error("VM not registered with the memory manager")
 		return nil, errors.New("VM not registered with the memory manager")
 	}


### PR DESCRIPTION
Currently, the memory manager is not always unlocked when an error is returned.