### PR TITLE
Add image manager to manage container image pulling

### DIFF
--- a/ctriface/bench_test.go
+++ b/ctriface/bench_test.go
@@ -69,7 +69,7 @@ func TestBenchmarkStart(t *testing.T) {
 		startMetrics := make([]*metrics.Metric, benchCount)
 
 		// Pull image
-		_, err := orch.getImage(ctx, imageName)
+		_, err := orch.imageManager.GetImage(ctx, imageName)
 		require.NoError(t, err, "Failed to pull image "+imageName)
 
 		for i := 0; i < benchCount; i++ {

--- a/ctriface/iface_test.go
+++ b/ctriface/iface_test.go
@@ -186,7 +186,7 @@ func TestStartStopParallel(t *testing.T) {
 	)
 
 	// Pull image
-	_, err := orch.getImage(ctx, testImageName)
+	_, err := orch.imageManager.GetImage(ctx, testImageName)
 	require.NoError(t, err, "Failed to pull image "+testImageName)
 
 	{
@@ -245,7 +245,7 @@ func TestPauseResumeParallel(t *testing.T) {
 	)
 
 	// Pull image
-	_, err := orch.getImage(ctx, testImageName)
+	_, err := orch.imageManager.GetImage(ctx, testImageName)
 	require.NoError(t, err, "Failed to pull image "+testImageName)
 
 	{

--- a/ctriface/manual_cleanup_test.go
+++ b/ctriface/manual_cleanup_test.go
@@ -174,7 +174,7 @@ func TestParallelSnapLoad(t *testing.T) {
 	)
 
 	// Pull image
-	_, err := orch.getImage(ctx, testImageName)
+	_, err := orch.imageManager.GetImage(ctx, testImageName)
 	require.NoError(t, err, "Failed to pull image "+testImageName)
 
 	var vmGroup sync.WaitGroup
@@ -236,7 +236,7 @@ func TestParallelPhasedSnapLoad(t *testing.T) {
 	)
 
 	// Pull image
-	_, err := orch.getImage(ctx, testImageName)
+	_, err := orch.imageManager.GetImage(ctx, testImageName)
 	require.NoError(t, err, "Failed to pull image "+testImageName)
 
 	{

--- a/ctriface/orch.go
+++ b/ctriface/orch.go
@@ -23,13 +23,14 @@
 package ctriface
 
 import (
+	"github.com/ease-lab/vhive/ctrimages"
 	"os"
 	"os/signal"
 	"path/filepath"
-	"syscall"
-	"time"
 	"strings"
 	"sync"
+	"syscall"
+	"time"
 
 	log "github.com/sirupsen/logrus"
 
@@ -79,6 +80,7 @@ type Orchestrator struct {
 	snapshotter  string
 	client       *containerd.Client
 	fcClient     *fcclient.Client
+	imageManager *ctrimages.ImageManager
 	// store *skv.KVStore
 	snapshotsEnabled bool
 	isUPFEnabled     bool
@@ -135,6 +137,9 @@ func NewOrchestrator(snapshotter, hostIface string, opts ...OrchestratorOption) 
 		log.Fatal("Failed to start firecracker client", err)
 	}
 	log.Info("Created firecracker client")
+
+	o.imageManager = ctrimages.NewImageManager(o.client, o.snapshotter)
+
 	return o
 }
 

--- a/ctrimages/imageManager.go
+++ b/ctrimages/imageManager.go
@@ -1,0 +1,143 @@
+// Package ctrimages provides an image manager that manages and caches container images.
+package ctrimages
+
+import (
+	"context"
+	"github.com/containerd/containerd"
+	"github.com/containerd/containerd/remotes/docker"
+	log "github.com/sirupsen/logrus"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+)
+
+// ImageState is used to synchronize image pulling to avoid pulling the same image multiple times concurrently.
+type ImageState struct {
+	sync.Mutex
+	pulled bool
+}
+
+// NewImageState creates a new ImageState object that can be used to synchronize image pulling.
+func NewImageState() *ImageState {
+	state := new(ImageState)
+	state.pulled = false
+	return state
+}
+
+// ImageManager manages the images that have been pulled to the node.
+type ImageManager struct {
+	sync.Mutex
+	snapshotter  string						 // image snapshotter
+	cachedImages map[string]containerd.Image // Cached container images
+	imageStates  map[string]*ImageState
+	client       *containerd.Client
+}
+
+// NewImageManager creates a new imagemanager that can be used to fetch container images.
+func NewImageManager(client *containerd.Client, snapshotter string) *ImageManager {
+	log.Info("Creating image manager")
+	manager := new(ImageManager)
+	manager.snapshotter = snapshotter
+	manager.cachedImages = make(map[string]containerd.Image)
+	manager.imageStates = make(map[string]*ImageState)
+	manager.client = client
+	return manager
+}
+
+// pullImage fetches an image and adds it to the cached image list
+func (mgr *ImageManager) pullImage(ctx context.Context, imageName string) error {
+	var err error
+	var image containerd.Image
+
+	imageURL := getImageURL(imageName)
+	local, _ := isLocalDomain(imageURL)
+	if local {
+		// Pull local image using HTTP
+		resolver := docker.NewResolver(docker.ResolverOptions{
+			Client: http.DefaultClient,
+			Hosts: docker.ConfigureDefaultRegistries(
+				docker.WithPlainHTTP(docker.MatchAllHosts),
+			),
+		})
+		image, err = mgr.client.Pull(ctx, imageURL,
+			containerd.WithPullUnpack,
+			containerd.WithPullSnapshotter(mgr.snapshotter),
+			containerd.WithResolver(resolver),
+		)
+	} else {
+		// Pull remote image
+		image, err = mgr.client.Pull(ctx, imageURL,
+			containerd.WithPullUnpack,
+			containerd.WithPullSnapshotter(mgr.snapshotter),
+		)
+	}
+	if err != nil {
+		return err
+	}
+	mgr.Lock()
+	mgr.cachedImages[imageName] = image
+	mgr.Unlock()
+	return nil
+}
+
+// GetImage fetches an image that can be used to create a container using containerd
+func (mgr *ImageManager) GetImage(ctx context.Context, imageName string) (*containerd.Image, error) {
+	mgr.Lock()
+	imgState, found := mgr.imageStates[imageName]
+	if !found {
+		imgState = NewImageState()
+		mgr.imageStates[imageName] = imgState
+	}
+	mgr.Unlock()
+
+	// Pull image if necessary
+	imgState.Lock()
+	if !imgState.pulled {
+		if err := mgr.pullImage(ctx, imageName); err != nil {
+			imgState.Unlock()
+			return nil, err
+		}
+		imgState.pulled = true
+	}
+	imgState.Unlock()
+
+	mgr.Lock()
+	image := mgr.cachedImages[imageName]
+	mgr.Unlock()
+
+	return &image, nil
+}
+
+// Converts an image name to a url if it is not a URL
+func getImageURL(image string) string {
+	// Pull from dockerhub by default if not specified (default k8s behavior)
+	if strings.Contains(image, ".") {
+		return image
+	}
+	return "docker.io/" + image
+
+}
+
+// Checks whether a URL has a .local domain
+func isLocalDomain(s string) (bool, error) {
+	if ! strings.Contains(s, "://") {
+		s = "dummy://" + s
+	}
+
+	u, err := url.Parse(s)
+	if err != nil {
+		return false, err
+	}
+
+	host, _, err := net.SplitHostPort(u.Host)
+	if err != nil {
+		host = u.Host
+	}
+
+	i := strings.LastIndex(host, ".")
+	tld := host[i+1:]
+
+	return tld == "local", nil
+}

--- a/scripts/install_pmutools.sh
+++ b/scripts/install_pmutools.sh
@@ -32,4 +32,4 @@ sudo git clone https://github.com/andikleen/pmu-tools /usr/local/pmu-tools
 sudo sysctl -w kernel.perf_event_paranoid=-1
 
 # first run, download essential files
-/usr/local/pmu-tools/toplev --print > /dev/null
+#/usr/local/pmu-tools/toplev --print > /dev/null


### PR DESCRIPTION
This PR adds an image manager which manages and serializes pulling of identical container images. This avoids unnecessary network congestion as well as a starting point to managing which container images are kept cached on a node.