### PR TITLE
Hotfix: #440. Error installing pmutools

### DIFF
--- a/scripts/install_pmutools.sh
+++ b/scripts/install_pmutools.sh
@@ -27,7 +27,7 @@ set -e
 sudo apt-get install numactl \
     linux-tools-`uname -r`  -y
 
-sudo git clone https://github.com/andikleen/pmu-tools /usr/local/pmu-tools
+sudo git clone https://github.com/ease-lab/pmu-tools -b master /usr/local/pmu-tools
 
 sudo sysctl -w kernel.perf_event_paranoid=-1
 


### PR DESCRIPTION
Due to a [bug ](https://github.com/andikleen/pmu-tools/issues/408) in the upstream repo installing pmutools does not work.
This hotfix should solve the problem until the bug is fixed in the upstream.