### PR TITLE
Reintroduce Error checking for container creation

### DIFF
--- a/cri/firecracker/service.go
+++ b/cri/firecracker/service.go
@@ -127,6 +127,12 @@ func (fs *FirecrackerService) createUserContainer(ctx context.Context, r *criapi
 
 	// Wait for placeholder UC to be created
 	<-stockDone
+	
+	// Check for error from container creation
+ 	if stockErr != nil {
+ 		log.WithError(stockErr).Error("failed to create container")
+ 		return nil, stockErr
+ 	}
 
 	containerdID := stockResp.ContainerId
 	err = fs.coordinator.insertActive(containerdID, funcInst)


### PR DESCRIPTION
This PR reintroduces the error check merged in #337. It seems to have disappeared between then and the most recent commit.