### PR TITLE
Proposal for extension with support for GitHub actions to Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,3 +35,11 @@ updates:
     directory: "/examples/invoker"
     schedule:
       interval: "weekly"
+
+  # Enable version updates for GitHub Actions
+  - package-ecosystem: "github-actions"
+    # Look for `.github/workflows` in the `root` directory
+    directory: "/"
+    # Check for updates once a week
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Summary

Hello, 

I wanted to propose an update to you spellcheck action configuration, but I saw that you were using Dependabot, so instead I am proposing a configuration for keeping your GitHub actions up to date.

If you would prefer to manually handle these, please let me know and I will create a PR with a proposal for an update to the Spellcheck action.

## Implementation Notes :hammer_and_pick:

* Update to Dependabot configuration so it will process and propose updates to GitHub actions, meaning the contents of: `workflows/`.

## External Dependencies :four_leaf_clover:

* Dependabot is enabled to handle GitHub action in addition to what it is already handling

## Breaking API Changes :warning:

* None

*Simply specify none (N/A) if not applicable.*
