### PR TITLE
Added Dependabot configuration for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,3 +35,10 @@ updates:
     directory: "/examples/invoker"
     schedule:
       interval: "weekly"
+
+  # Enable version updates for Actions
+  - package-ecosystem: "github-actions"
+    # Look for `.github/workflows` in the `root` directory
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Summary

I wanted to bump the dependency for the Spellcheck GitHub Action to the latest version, when I noticed, that you already use Dependabot. So instead I am proposing adding the configuration to have Dependabot manage the GitHub Actions used in the repository

## Implementation Notes :hammer_and_pick:

* The Dependabot configuration is scheduled to run weekly, which matches the other configurations. The implementation checks GitHub Actions, which are located in `.github/workflows/` so the configuration points to the directory of the `.github` repository.

## External Dependencies :four_leaf_clover:

* Dependabot is already configured

## Breaking API Changes :warning:

* None

*Simply specify none (N/A) if not applicable.*
