### PR TITLE
fix cri runners

### DIFF
--- a/.github/workflows/gvisor_cri_tests.yml
+++ b/.github/workflows/gvisor_cri_tests.yml
@@ -38,6 +38,7 @@ jobs:
       run: |
         echo $HOSTNAME
         echo $GITHUB_RUN_ID
+        
     - name: Setup TMPDIR
       run: mkdir -p $TMPDIR
 

--- a/scripts/github_runner/setup_runner_cri.sh
+++ b/scripts/github_runner/setup_runner_cri.sh
@@ -33,7 +33,7 @@ fi
 cd $HOME
 if [ ! -d "$HOME/actions-runner" ]; then
     mkdir actions-runner && cd actions-runner
-    LATEST_VERSION=$(curl -s https://api.github.com/repos/actions/runner/releases/latest | grep 'browser_' | cut -d\" -f4 | grep linux-x64)
+    LATEST_VERSION=$(curl -s https://api.github.com/repos/actions/runner/releases/latest | grep 'browser_' | cut -d\" -f4 | grep 'linux-x64-[0-9\.]*.tar.gz')
     curl -o actions-runner-linux-x64.tar.gz -L -C - $LATEST_VERSION
     tar xzf "./actions-runner-linux-x64.tar.gz"
     rm actions-runner-linux-x64.tar.gz

--- a/scripts/github_runner/setup_runner_host.sh
+++ b/scripts/github_runner/setup_runner_host.sh
@@ -59,14 +59,14 @@ cd /tmp/kind
 source /etc/profile && go build
 sudo mv kind /usr/local/bin/
 
-sudo usermod -aG docker $USER
-newgrp docker
-
 # Allow profiling using Perf / PMU tools
 sudo sysctl -w kernel.perf_event_paranoid=-1
 
 # Kube-proxy
 sudo sysctl -w net.netfilter.nf_conntrack_max=655360
 
-# Disable swap
-sudo swapoff -a
+# Disable swap, continue even it this fails
+sudo swapoff -a || :
+
+sudo usermod -aG docker $USER
+newgrp docker 

--- a/scripts/github_runner/setup_runner_host.sh
+++ b/scripts/github_runner/setup_runner_host.sh
@@ -59,9 +59,6 @@ cd /tmp/kind
 source /etc/profile && go build
 sudo mv kind /usr/local/bin/
 
-# Disable swap
-sudo swapoff -a
-
 sudo usermod -aG docker $USER
 newgrp docker
 
@@ -70,3 +67,6 @@ sudo sysctl -w kernel.perf_event_paranoid=-1
 
 # Kube-proxy
 sudo sysctl -w net.netfilter.nf_conntrack_max=655360
+
+# Disable swap
+sudo swapoff -a

--- a/scripts/github_runner/setup_runner_host.sh
+++ b/scripts/github_runner/setup_runner_host.sh
@@ -68,3 +68,5 @@ newgrp docker
 # Allow profiling using Perf / PMU tools
 sudo sysctl -w kernel.perf_event_paranoid=-1
 
+# Kube-proxy
+sudo sysctl -w net.netfilter.nf_conntrack_max=655360

--- a/scripts/github_runner/start_bare-metal_runner.sh
+++ b/scripts/github_runner/start_bare-metal_runner.sh
@@ -39,7 +39,7 @@ cd vhive
 cd
 mkdir actions-runner && cd actions-runner
 
-curl -o actions-runner-linux-x64.tar.gz -L -C - $(curl -s https://api.github.com/repos/actions/runner/releases/latest | grep 'browser_' | cut -d\" -f4 | grep linux-x64)
+curl -o actions-runner-linux-x64.tar.gz -L -C - $(curl -s https://api.github.com/repos/actions/runner/releases/latest | grep 'browser_' | cut -d\" -f4 | grep 'linux-x64-[0-9\.]*.tar.gz')
 tar xzf "./actions-runner-linux-x64.tar.gz"
 rm actions-runner-linux-x64.tar.gz
 


### PR DESCRIPTION
Signed-off-by: Shyam Jesal <s.jesalpura@gmail.com>

## Summary
fix CRI runners

## Implementation Notes :hammer_and_pick:

- update `max_conntrack` limit for runner host. ref: [here](https://serverfault.com/questions/769978/sysctl-cannot-stat-proc-sys-net-ipv4-netfilter-ip-conntrack-max-no-such-file)
- fix actions-runner download link in [setup_runner_cri.sh](https://github.com/ease-lab/vhive/blob/main/scripts/github_runner/setup_runner_cri.sh) and [start_bare-metal_runner.sh](https://github.com/ease-lab/vhive/blob/main/scripts/github_runner/start_bare-metal_runner.sh).
- reorder instructions in [setup_runner_host.sh](https://github.com/ease-lab/vhive/blob/main/scripts/github_runner/setup_runner_host.sh)
