### PR TITLE
Serverless & vHive tutorial at ASPLOS'22 (announcement)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@
 
 ![vHive Header](docs/figures/vhive_hdr.jpg)
 
+## News
+
+A full-day tutorial, co-located with the ASPLOS'22 conference, is going to take place in Lausanne, Switzerland on March 1. The tutorial will be in a hybrid format (both in-person and virtual) and will cover both the serverless cloud foundations and the vHive ecosystem and include several hands-on sessions. In this tutorial, the participants will learn how to analyze performance of commercial and open-source clouds as well as how to experiment and innovate across serverless stack using vHive. For more information, please visit the [tutorial webpage](https://ease-lab.github.io/vhive-asplos22).
+
 ## Mission
 
 vHive aims to enable serverless systems researchers to innovate across the deep and distributed software stacks

--- a/configs/.wordlist.txt
+++ b/configs/.wordlist.txt
@@ -252,6 +252,7 @@ KVM
 lan
 latencies
 latSamples
+Lausanne
 ldquo
 Letraset
 lfs
@@ -521,6 +522,7 @@ vSwarm
 warmUpTime
 wc
 WDDD
+webpage
 wget
 WIDX
 WIOSCA


### PR DESCRIPTION
A full-day tutorial, co-located with the ASPLOS'22 conference, is going to take place in Lausanne, Switzerland on March 1. The tutorial will be in a hybrid format (both in-person and virtual) and will cover both the serverless cloud foundations and the vHive ecosystem and include several hands-on sessions. In this tutorial, the participants will learn how to analyze performance of commercial and open-source clouds as well as how to experiment and innovate across serverless stack using vHive. For more information, please visit the [tutorial webpage](https://ease-lab.github.io/vhive-asplos22/).

Signed-off-by: Dmitrii Ustiugov <dmitrii.ustiugov@ed.ac.uk>