### PR TITLE
Fixes ubuntu desktop image error of package not found

### DIFF
--- a/scripts/setup_system.sh
+++ b/scripts/setup_system.sh
@@ -22,17 +22,18 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-# Add skopeo sources
  . /etc/os-release
+sudo apt-get -y install curl ca-certificates >> /dev/null
+sudo add-apt-repository universe >> /dev/null
+sudo apt-get update >> /dev/null
  echo "deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/ /" | sudo tee /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list > /dev/null
+# Add skopeo sources
  curl --silent --show-error -L https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/Release.key | sudo apt-key add -
 
 sudo apt-get update >> /dev/null
 
 sudo apt-get -y install \
     apt-transport-https \
-    ca-certificates \
-    curl \
     gcc \
     g++ \
     make \


### PR DESCRIPTION
## Summary

Fixes #473 .

## Implementation Notes :hammer_and_pick:

* Adds universe repository in ubuntu
* Adds ca-certificates package to pull from opensuse repo

## External Dependencies :four_leaf_clover:

* N/A

## Breaking API Changes :warning:

* N/A

*Simply specify none (N/A) if not applicable.*
