### PR TITLE
Fix k8s cluster boot inside cri test runner

### DIFF
--- a/configs/kind/kubeadm.conf
+++ b/configs/kind/kubeadm.conf
@@ -1,0 +1,25 @@
+apiVersion: kubeadm.k8s.io/v1beta3
+kind: ClusterConfiguration
+kubernetesVersion: v1.23.5
+networking:
+  podSubnet: 192.168.0.0/16
+scheduler:
+  extraArgs: null
+---
+apiVersion: kubelet.config.k8s.io/v1beta1
+cgroupDriver: cgroupfs
+kind: KubeletConfiguration
+---
+apiVersion: kubeadm.k8s.io/v1beta3
+kind: InitConfiguration
+nodeRegistration:
+  criSocket: ${CRI_SOCK}
+  kubeletExtraArgs:
+    fail-swap-on: "false"
+---
+apiVersion: kubeadm.k8s.io/v1beta3
+kind: JoinConfiguration
+nodeRegistration:
+  criSocket: ${CRI_SOCK}
+  kubeletExtraArgs:
+    fail-swap-on: "false"

--- a/scripts/cluster/create_one_node_cluster.sh
+++ b/scripts/cluster/create_one_node_cluster.sh
@@ -36,7 +36,14 @@ else
     CRI_SOCK="/etc/vhive-cri/vhive-cri.sock"
 fi
 
-sudo kubeadm init --ignore-preflight-errors=all --cri-socket $CRI_SOCK --pod-network-cidr=192.168.0.0/16
+# Docker container ID is 64 characters long.
+if [ 64 -eq ${#CONTAINERID} ]; then
+  # create cluster using the config file
+  CRI_SOCK=$CRI_SOCK envsubst < "/scripts/kubeadm.conf" > "/scripts/kubeadm_patched.conf"
+  sudo kubeadm init --skip-phases="preflight" --config=<(envsubst < "/scripts/kubeadm_patched.conf")
+else
+    sudo kubeadm init --ignore-preflight-errors=all --cri-socket $CRI_SOCK --pod-network-cidr=192.168.0.0/16
+fi
 
 mkdir -p $HOME/.kube
 sudo cp -i /etc/kubernetes/admin.conf $HOME/.kube/config

--- a/scripts/github_runner/Dockerfile.cri_dev_env
+++ b/scripts/github_runner/Dockerfile.cri_dev_env
@@ -23,15 +23,12 @@
 FROM kindest/node:v1.23.5
 
 RUN apt-get update && \
-    apt-get install -y gnupg2 && \
-    echo "deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_20.04/ /" | tee /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list && \
-    curl -L https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_20.04/Release.key | apt-key add - && \
-    apt-get update && \
     apt-get upgrade --yes && \
     apt-get install --yes \
     apt-utils && \
     DEBIAN_FRONTEND="noninteractive" apt-get install --yes \
     sudo \
+    gnupg2 \
     wget curl\
     gcc g++\
     iproute2 iptables net-tools nftables \
@@ -59,6 +56,7 @@ RUN apt-get update && \
 COPY scripts/github_runner/setup_cri_dev_env.sh /scripts/
 COPY scripts/setup_system.sh /scripts/
 COPY scripts/create_devmapper.sh /scripts/
+COPY configs/kind/kubeadm.conf /scripts/
 RUN chmod +x /scripts/setup_system.sh && \
     chmod +x /scripts/create_devmapper.sh && \
     chmod +x /scripts/setup_cri_dev_env.sh

--- a/scripts/github_runner/Dockerfile.github_runner_cri
+++ b/scripts/github_runner/Dockerfile.github_runner_cri
@@ -20,7 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-FROM vhiveease/vhive_dev_env:1.23.5
+FROM vhiveease/vhive_dev_env:v1.23.5
 
 RUN sudo apt remove -y vim tmux
 COPY scripts/github_runner/setup_runner_cri.sh /scripts/

--- a/scripts/github_runner/setup_runner.sh
+++ b/scripts/github_runner/setup_runner.sh
@@ -44,7 +44,7 @@ fi
 cd $HOME
 if [ ! -d "$HOME/actions-runner" ]; then
     mkdir actions-runner && cd actions-runner
-    LATEST_VERSION=$(curl -s https://api.github.com/repos/actions/runner/releases/latest | grep 'browser_' | cut -d\" -f4 | grep linux-x64)
+    LATEST_VERSION=$(curl -s https://api.github.com/repos/actions/runner/releases/latest | grep 'browser_' | cut -d\" -f4 | grep 'linux-x64-[0-9\.]*.tar.gz')
     curl -o actions-runner-linux-x64.tar.gz -L -C - $LATEST_VERSION
     tar xzf "./actions-runner-linux-x64.tar.gz"
     rm actions-runner-linux-x64.tar.gz

--- a/scripts/github_runner/setup_runner_host.sh
+++ b/scripts/github_runner/setup_runner_host.sh
@@ -54,7 +54,7 @@ $PWD/../install_go.sh
 
 # install kind from ease-lab/kind
 rm -rf /tmp/kind/
-git clone -b custom_docker_params_for_vHive https://github.com/ease-lab/kind /tmp/kind/
+git clone -b custom_docker_params_for_vHive_v0.12.0 https://github.com/ease-lab/kind /tmp/kind/
 cd /tmp/kind
 source /etc/profile && go build
 sudo mv kind /usr/local/bin/

--- a/scripts/github_runner/start_runners.sh
+++ b/scripts/github_runner/start_runners.sh
@@ -54,7 +54,7 @@ case "$RUNNER_LABEL" in
 "integ")
     # pull latest images
     docker pull vhiveease/integ_test_runner:ubuntu20base
-    docker pull vhiveease/cri_test_runner:1.23.5
+    docker pull vhiveease/cri_test_runner:v1.23.5
 
     if [ "$RESTART_FLAG" == "restart" ]; then
         docker container stop $(docker ps --format "{{.Names}}" | grep integration_test-github_runner)
@@ -80,14 +80,14 @@ case "$RUNNER_LABEL" in
 "cri")
     # pull latest images
     docker pull vhiveease/integ_test_runner:ubuntu20base
-    docker pull vhiveease/cri_test_runner:1.23.5
+    docker pull vhiveease/cri_test_runner:v1.23.5
 
     if [ "$RESTART_FLAG" == "restart" ]; then
         kind get clusters | while read line ; do kind delete cluster --name "$line" ; done
     fi
     for number in $(seq 1 $NUM_OF_RUNNERS)
     do
-        kind create cluster --image vhiveease/cri_test_runner:1.23.5 --name "cri-test-github-runner-${HOSTNAME}-${number}"
+        kind create cluster --image vhiveease/cri_test_runner:v1.23.5 --name "cri-test-github-runner-${HOSTNAME}-${number}"
         sleep 2m
         docker exec -it \
             -e RUNNER_ALLOW_RUNASROOT=1 \

--- a/scripts/setup_system.sh
+++ b/scripts/setup_system.sh
@@ -24,12 +24,7 @@
 
  . /etc/os-release
 sudo apt-get -y install curl ca-certificates >> /dev/null
-sudo add-apt-repository universe >> /dev/null
-sudo apt-get update >> /dev/null
- echo "deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/ /" | sudo tee /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list > /dev/null
-# Add skopeo sources
- curl --silent --show-error -L https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/Release.key | sudo apt-key add -
-
+sudo add-apt-repository -y universe >> /dev/null
 sudo apt-get update >> /dev/null
 
 sudo apt-get -y install \


### PR DESCRIPTION
## Summary

Fixed the kind runner bootup.

## Implementation Notes :hammer_and_pick:

added `configs/kind/kubeadm.conf` to boot kind cluster without cgroup errors.
fixed `scripts/cluster/create_one_node_cluster.sh` to use the above config while executing `kubeadm init`
