### PR TITLE
Do not set GOROOT in workflows

### DIFF
--- a/.github/workflows/cri_minio_test.yml
+++ b/.github/workflows/cri_minio_test.yml
@@ -23,7 +23,6 @@ env:
   TMPDIR: /root/tmp/
   GOCACHE: /root/tmp/gocache
   GOPATH: /root/tmp/gopath
-  GOROOT: $HOME/go
   KUBECONFIG: /etc/kubernetes/admin.conf
 
 jobs:

--- a/.github/workflows/nightly_tests.yml
+++ b/.github/workflows/nightly_tests.yml
@@ -11,7 +11,6 @@ env:
   TMPDIR: /root/tmp/
   GOCACHE: /root/tmp/gocache
   GOPATH: /root/tmp/gopath
-  GOROOT: $HOME/go
 
 jobs:
   integration-tests:


### PR DESCRIPTION
Fixes failing nightly tests due to setup-go action's failure. Explained [here](https://github.com/actions/setup-go/issues/235#issuecomment-1127435881).